### PR TITLE
liquidityOf() returns 0 for a wiped tranche

### DIFF
--- a/src/LendingPool.sol
+++ b/src/LendingPool.sol
@@ -235,6 +235,7 @@ contract LendingPool is Guardian, TrustedCreditor, DebtToken, InterestRateModule
         interestWeightTranches.pop();
         liquidationWeightTranches.pop();
         tranches.pop();
+        interestWeight[tranche] = 0;
 
         emit TranchePopped(tranche);
     }
@@ -591,8 +592,6 @@ contract LendingPool is Guardian, TrustedCreditor, DebtToken, InterestRateModule
      * @return assets The redeemable amount of liquidity in the underlying asset.
      */
     function liquidityOf(address owner_) external view returns (uint256 assets) {
-        // If owner_ is not a tranche, redeemable amount = 0.
-        if (!isTranche[owner_]) return 0;
         // Avoid a second calculation of unrealised debt (expensive).
         // if interests are already synced this block.
         if (lastSyncedTimestamp != uint32(block.timestamp)) {

--- a/test_old/LendingPool.t.sol
+++ b/test_old/LendingPool.t.sol
@@ -2655,6 +2655,10 @@ contract LiquidationTest is LendingPoolTest {
         vm.prank(address(pool));
         jrTranche.setAuctionInProgress(true);
 
+        // Before settling the liquidation that will wipe out the jr tranche, we ensure that the jr tranche has an interestWeight > 0
+        // This will ensure our testing below of liquidityOf() is valid
+        stdstore.target(address(pool)).sig(pool.interestWeight.selector).with_key(address(jrTranche)).checked_write(100);
+
         // When: Liquidator settles a liquidation
         vm.prank(address(liquidator));
         pool.settleLiquidation(address(account), accountOwner, badDebt, 0, 0, 0);
@@ -2672,7 +2676,6 @@ contract LiquidationTest is LendingPoolTest {
         assertTrue(srTranche.auctionInProgress());
 
         // Here we ensure that interests are available, but liquidityOf() should return 0 for junior tranche as it was wiped.
-        stdstore.target(address(pool)).sig(pool.interestWeight.selector).with_key(address(jrTranche)).checked_write(100);
         pool.setInterestRate(10 ether);
         pool.setRealisedDebt(10_000 ether);
         vm.warp(block.timestamp + 30 days);


### PR DESCRIPTION
This PR accomplishes the following:

-AF-29: Ensures that in the case a tranche was wiped out due to bad debt, the function `liquidityOf()` returns 0 in `LendingPool.sol`.