### PR TITLE
Af 307 pl mint debt on initiation

### DIFF
--- a/script/DeployLending.s.sol
+++ b/script/DeployLending.s.sol
@@ -47,7 +47,7 @@ contract ArcadiaLendingDeployment is Test {
         srTranche_weth = new Tranche(address(pool_weth), "Senior", "sr");
 
         pool_weth.setOriginationFee(10);
-        pool_weth.setMaxInitiatorFee(3 * 10 ** 18);
+        pool_weth.setMaxLiquidationFees(3 * 10 ** 18, 3 * 10 ** 18);
         pool_weth.setFixedLiquidationCost(0.002 * 10 ** 18);
         pool_weth.addTranche(address(srTranche_weth), 85, 10);
         pool_weth.setTreasuryInterestWeight(15);
@@ -69,7 +69,7 @@ contract ArcadiaLendingDeployment is Test {
         srTranche_usdc = new Tranche(address(pool_usdc), "Senior", "sr");
 
         pool_usdc.setOriginationFee(10);
-        pool_usdc.setMaxInitiatorFee(5000 * 10 ** 6);
+        pool_usdc.setMaxLiquidationFees(5000 * 10 ** 6, 5000 * 10 ** 6);
         pool_usdc.setFixedLiquidationCost(2 * 10 ** 6);
         pool_usdc.addTranche(address(srTranche_usdc), 85, 10);
         pool_usdc.setTreasuryInterestWeight(15);

--- a/src/LendingPool.sol
+++ b/src/LendingPool.sol
@@ -62,7 +62,7 @@ contract LendingPool is LendingPoolGuardian, TrustedCreditor, DebtToken, Interes
     // Conservative estimate of the maximal gas cost to liquidate a position (fixed cost, independent of openDebt).
     uint96 internal fixedLiquidationCost;
     // Maximum amount of `underlying asset` that is paid as fee to the initiator of a liquidation.
-    uint80 public maxInitiatorFee;
+    uint80 internal maxInitiatorFee;
     // Number of auctions that are currently in progress.
     uint16 internal auctionsInProgress;
     // Address of the protocol treasury.
@@ -802,7 +802,6 @@ contract LendingPool is LendingPoolGuardian, TrustedCreditor, DebtToken, Interes
      * @dev At the start of the liquidation the debt tokens are burned,
      * as such interests are not accrued during the liquidation.
      */
-
     function liquidateAccount(address account) external whenLiquidationNotPaused processInterests {
         //Only Accounts can have debt, and debtTokens are non-transferrable.
         //Hence by checking that the balance of the address passed as Account is not 0, we know the address
@@ -962,6 +961,10 @@ contract LendingPool is LendingPoolGuardian, TrustedCreditor, DebtToken, Interes
     /**
      * @notice Start a liquidation for a specific account with debt.
      * @param account The address of the account with debt to be liquidated.
+     * @param initiatorRewardWeight Fee paid to the Liquidation Initiator.
+     * @param penaltyWeight Penalty the Account owner has to pay to the trusted Creditor on top of the open Debt for being liquidated.
+     * @param closingRewardWeight Fee paid to the address that is ending an auction.
+     * @return maxInitiatorFee_ Maximum amount of `underlying asset` that is paid as fee to the initiator of a liquidation.
      * @dev This function can only be called by authorized liquidators.
      * @dev To initiate a liquidation, the function checks if the specified account has open debt.
      * @dev If the account has no open debt, the function reverts with an error.
@@ -969,20 +972,29 @@ contract LendingPool is LendingPoolGuardian, TrustedCreditor, DebtToken, Interes
      * @dev The function updates the count of ongoing auctions.
      * @dev Liquidations can only be initiated for accounts with non-zero open debt.
      */
-    function startLiquidation(address account, uint256 liquidationIncentives)
-        external
-        onlyLiquidator
-        whenLiquidationNotPaused
-        processInterests
-    {
+    function startLiquidation(
+        address account,
+        uint256 initiatorRewardWeight,
+        uint256 penaltyWeight,
+        uint256 closingRewardWeight
+    ) external onlyLiquidator whenLiquidationNotPaused processInterests returns (uint80 maxInitiatorFee_) {
         //Only Accounts can have debt, and debtTokens are non-transferrable.
         //Hence by checking that the balance of the address passed as Account is not 0, we know the address
         //passed as Account is indeed a Account and has debt.
         uint256 openDebt = maxWithdraw(account);
         if (openDebt == 0) revert LendingPool_IsNotAnAccountWithDebt();
 
+        maxInitiatorFee_ = maxInitiatorFee;
+
+        // Calculate liquidation incentives which should be considered as extra debt for the Account
+        uint256 liquidationInitiatorReward = openDebt * initiatorRewardWeight / 100;
+        liquidationInitiatorReward =
+            liquidationInitiatorReward > maxInitiatorFee_ ? maxInitiatorFee_ : liquidationInitiatorReward;
+        uint256 liquidationPenalty = openDebt * penaltyWeight / 100;
+        uint256 closingReward = openDebt * closingRewardWeight / 100;
+
         // Mint extra debt towards the Account (as incentives should be considered in order to bring Account to a healthy state)
-        _deposit(liquidationIncentives, account);
+        _deposit(liquidationInitiatorReward + liquidationPenalty + closingReward, account);
 
         //Hook to the most junior Tranche, to inform that auctions are ongoing,
         //already done if there are other auctions in progress (auctionsInProgress > O).

--- a/src/LendingPool.sol
+++ b/src/LendingPool.sol
@@ -101,7 +101,7 @@ contract LendingPool is LendingPoolGuardian, TrustedCreditor, DebtToken, Interes
     event TrancheAdded(address indexed tranche, uint8 indexed index, uint16 interestWeight, uint16 liquidationWeight);
     event InterestWeightSet(uint256 indexed index, uint16 weight);
     event LiquidationWeightSet(uint256 indexed index, uint16 weight);
-    event MaxInitiatorFeeSet(uint80 maxInitiatorFee);
+    event MaxLiquidationFeesSet(uint80 maxInitiatorFee, uint80 maxClosingFee);
     event TranchePopped(address tranche);
     event TreasuryInterestWeightSet(uint16 weight);
     event TreasuryLiquidationWeightSet(uint16 weight);
@@ -779,10 +779,11 @@ contract LendingPool is LendingPoolGuardian, TrustedCreditor, DebtToken, Interes
      * @dev The liquidator sets the % of the debt that is paid to the initiator of a liquidation.
      * This fee is capped by the maxInitiatorFee.
      */
-    function setMaxInitiatorFee(uint80 maxInitiatorFee_) external onlyOwner {
+    function setMaxLiquidationFees(uint80 maxInitiatorFee_, uint80 maxClosingFee_) external onlyOwner {
         maxInitiatorFee = maxInitiatorFee_;
+        maxClosingFee = maxClosingFee_;
 
-        emit MaxInitiatorFeeSet(maxInitiatorFee_);
+        emit MaxLiquidationFeesSet(maxInitiatorFee_, maxClosingFee_);
     }
 
     /**

--- a/src/LendingPool.sol
+++ b/src/LendingPool.sol
@@ -969,15 +969,12 @@ contract LendingPool is LendingPoolGuardian, TrustedCreditor, DebtToken, Interes
      * @dev The function updates the count of ongoing auctions.
      * @dev Liquidations can only be initiated for accounts with non-zero open debt.
      */
-    function startLiquidation(address account, uint256 debt, uint256 liquidationIncentives) external onlyLiquidator {
-        //Only Accounts can have debt, and debtTokens are non-transferable.
-        //Hence by checking that the balance of the address passed as Account is not 0, we know the address
-        //passed as Account is indeed a Account and has debt.
-
-        // Note : is this really needed, as we previously verify in checkAndStartLiquidation() that the account has openDebt > 0
-        uint256 openDebt = maxWithdraw(account);
-        if (openDebt == 0) revert LendingPool_IsNotAnAccountWithDebt();
-
+    function startLiquidation(address account, uint256 liquidationIncentives)
+        external
+        onlyLiquidator
+        whenLiquidationNotPaused
+        processInterests
+    {
         // Mint extra debt towards the Account (as incentives should be considered in order to bring Account to a healthy state)
         _deposit(liquidationIncentives, account);
 

--- a/src/LendingPool.sol
+++ b/src/LendingPool.sol
@@ -975,6 +975,12 @@ contract LendingPool is LendingPoolGuardian, TrustedCreditor, DebtToken, Interes
         whenLiquidationNotPaused
         processInterests
     {
+        //Only Accounts can have debt, and debtTokens are non-transferrable.
+        //Hence by checking that the balance of the address passed as Account is not 0, we know the address
+        //passed as Account is indeed a Account and has debt.
+        uint256 openDebt = maxWithdraw(account);
+        if (openDebt == 0) revert LendingPool_IsNotAnAccountWithDebt();
+
         // Mint extra debt towards the Account (as incentives should be considered in order to bring Account to a healthy state)
         _deposit(liquidationIncentives, account);
 

--- a/src/LendingPool.sol
+++ b/src/LendingPool.sol
@@ -63,6 +63,8 @@ contract LendingPool is LendingPoolGuardian, TrustedCreditor, DebtToken, Interes
     uint96 internal fixedLiquidationCost;
     // Maximum amount of `underlying asset` that is paid as fee to the initiator of a liquidation.
     uint80 internal maxInitiatorFee;
+    // Maximum amount of `underlying asset` that is paid as fee to the terminator of a liquidation.
+    uint80 internal maxClosingFee;
     // Number of auctions that are currently in progress.
     uint16 internal auctionsInProgress;
     // Address of the protocol treasury.
@@ -964,7 +966,9 @@ contract LendingPool is LendingPoolGuardian, TrustedCreditor, DebtToken, Interes
      * @param initiatorRewardWeight Fee paid to the Liquidation Initiator.
      * @param penaltyWeight Penalty the Account owner has to pay to the trusted Creditor on top of the open Debt for being liquidated.
      * @param closingRewardWeight Fee paid to the address that is ending an auction.
-     * @return maxInitiatorFee_ Maximum amount of `underlying asset` that is paid as fee to the initiator of a liquidation.
+     * @return liquidationInitiatorReward Fee paid to the Liquidation Initiator.
+     * @return closingReward Fee paid to the address that is ending an auction.
+     * @return liquidationPenalty Penalty paid by the account owner to the trusted Creditor on top of the open Debt for being liquidated.
      * @dev This function can only be called by authorized liquidators.
      * @dev To initiate a liquidation, the function checks if the specified account has open debt.
      * @dev If the account has no open debt, the function reverts with an error.
@@ -977,21 +981,29 @@ contract LendingPool is LendingPoolGuardian, TrustedCreditor, DebtToken, Interes
         uint256 initiatorRewardWeight,
         uint256 penaltyWeight,
         uint256 closingRewardWeight
-    ) external onlyLiquidator whenLiquidationNotPaused processInterests returns (uint80 maxInitiatorFee_) {
+    )
+        external
+        onlyLiquidator
+        whenLiquidationNotPaused
+        processInterests
+        returns (uint256 liquidationInitiatorReward, uint256 closingReward, uint256 liquidationPenalty)
+    {
         //Only Accounts can have debt, and debtTokens are non-transferrable.
         //Hence by checking that the balance of the address passed as Account is not 0, we know the address
         //passed as Account is indeed a Account and has debt.
         uint256 openDebt = maxWithdraw(account);
         if (openDebt == 0) revert LendingPool_IsNotAnAccountWithDebt();
 
-        maxInitiatorFee_ = maxInitiatorFee;
+        uint80 maxInitiatorFee_ = maxInitiatorFee;
+        uint80 maxClosingFee_ = maxClosingFee;
 
         // Calculate liquidation incentives which should be considered as extra debt for the Account
-        uint256 liquidationInitiatorReward = openDebt * initiatorRewardWeight / 100;
+        liquidationInitiatorReward = openDebt * initiatorRewardWeight / 100;
         liquidationInitiatorReward =
             liquidationInitiatorReward > maxInitiatorFee_ ? maxInitiatorFee_ : liquidationInitiatorReward;
-        uint256 liquidationPenalty = openDebt * penaltyWeight / 100;
-        uint256 closingReward = openDebt * closingRewardWeight / 100;
+        liquidationPenalty = openDebt * penaltyWeight / 100;
+        closingReward = openDebt * closingRewardWeight / 100;
+        closingReward = closingReward > maxClosingFee_ ? maxClosingFee_ : closingReward;
 
         // Mint extra debt towards the Account (as incentives should be considered in order to bring Account to a healthy state)
         _deposit(liquidationInitiatorReward + liquidationPenalty + closingReward, account);

--- a/src/Liquidator_NEW.sol
+++ b/src/Liquidator_NEW.sol
@@ -42,25 +42,33 @@ contract Liquidator_NEW is Owned {
     // Penalty the Account owner has to pay to the trusted Creditor on top of the open Debt for being liquidated.
     // Defined as a fraction of the openDebt with 2 decimals precision.
     uint8 internal penaltyWeight;
+    // Fee paid to the address that is ending an auction.
+    // Defined as a fraction of the openDebt with 2 decimals precision.
+    uint8 internal closingRewardWeight;
 
     // Map Account => auctionInformation.
     mapping(address => AuctionInformation) public auctionInformation;
 
     // Struct with additional information about the auction of a specific Account.
     struct AuctionInformation {
-        uint256 startPrice; // The open debt, same decimal precision as baseCurrency.
+        uint256 startPrice;
+        uint128 startDebt; // The open debt, same decimal precision as baseCurrency.
         uint32 startTime; // The timestamp the auction started.
-        uint256 paidDebt; // The amount of debt that has been paid off.
         bool inAuction; // Flag indicating if the auction is still ongoing.
+        uint80 maxInitiatorFee; // The max initiation fee, same decimal precision as baseCurrency.
         address initiator; // The address of the initiator of the auction.
         uint32[] assetShares; // The distribution of the assets in the Account. it is in 6 decimal precision -> 1000000 = 100%, 100000 = 10% . The order of the assets is the same as in the Account.
+        uint8 initiatorRewardWeight; // 2 decimals precision.
+        uint8 penaltyWeight; // 2 decimals precision.
+        uint8 closingRewardWeight; // 2 decimals precision.
+        address trustedCreditor; // The creditor that issued the debt.
     }
 
     /* //////////////////////////////////////////////////////////////
                                 EVENTS
     ////////////////////////////////////////////////////////////// */
 
-    event WeightsSet(uint8 initiatorRewardWeight, uint8 penaltyWeight);
+    event WeightsSet(uint8 initiatorRewardWeight, uint8 penaltyWeight, uint8 closingRewardWeight);
     event AuctionCurveParametersSet(uint64 base, uint16 cutoffTime);
     event StartPriceMultiplierSet(uint16 startPriceMultiplier);
     event MinimumPriceMultiplierSet(uint8 minPriceMultiplier);
@@ -108,13 +116,17 @@ contract Liquidator_NEW is Owned {
      * @param penaltyWeight_ Penalty paid by the Account owner to the trusted Creditor.
      * @dev Each weight has 2 decimals precision (50 equals 0,5 or 50%).
      */
-    function setWeights(uint256 initiatorRewardWeight_, uint256 penaltyWeight_) external onlyOwner {
-        require(initiatorRewardWeight_ + penaltyWeight_ <= 11, "LQ_SW: Weights Too High");
+    function setWeights(uint256 initiatorRewardWeight_, uint256 penaltyWeight_, uint256 closingRewardWeight_)
+        external
+        onlyOwner
+    {
+        require(initiatorRewardWeight_ + penaltyWeight_ + closingRewardWeight_ <= 11, "LQ_SW: Weights Too High");
 
         initiatorRewardWeight = uint8(initiatorRewardWeight_);
         penaltyWeight = uint8(penaltyWeight_);
+        closingRewardWeight = uint8(closingRewardWeight_);
 
-        emit WeightsSet(uint8(initiatorRewardWeight_), uint8(penaltyWeight_));
+        emit WeightsSet(uint8(initiatorRewardWeight_), uint8(penaltyWeight_), uint8(closingRewardWeight_));
     }
 
     /**
@@ -214,13 +226,38 @@ contract Liquidator_NEW is Owned {
             RiskModule.AssetValueAndRiskVariables[] memory riskValues
         ) = IAccount_NEW(account).checkAndStartLiquidation();
 
-        // Check if the account has debt in the lending pool and if so, increment auction in progress counter.
-        ILendingPool_NEW(creditor).startLiquidation(account, debt);
+        // Cache weights
+        uint8 initiatorRewardWeight_ = initiatorRewardWeight;
+        uint8 penaltyWeight_ = penaltyWeight;
+        uint8 closingRewardWeight_ = closingRewardWeight;
 
         // Fill the auction struct
+        auctionInformation[account].initiatorRewardWeight = initiatorRewardWeight_;
+        auctionInformation[account].penaltyWeight = penaltyWeight_;
+        auctionInformation[account].closingRewardWeight = closingRewardWeight_;
+
+        uint80 maxInitiatorFee = ILendingPool_NEW(creditor).maxInitiatorFee();
+
+        // Calculate liquidation incentives which should be considered as extra debt for the Account
+        // note: unchecked math ?
+        uint256 liquidationInitiatorReward = debt * initiatorRewardWeight_ / 100;
+        liquidationInitiatorReward =
+            liquidationInitiatorReward > maxInitiatorFee ? maxInitiatorFee : liquidationInitiatorReward;
+        uint256 liquidationPenalty = debt * penaltyWeight_ / 100;
+        uint256 closingReward = debt * closingRewardWeight_ / 100;
+
+        uint256 liquidationIncentives = liquidationInitiatorReward + liquidationPenalty + closingReward;
+
+        // Check if the account has debt in the lending pool and if so, increment auction in progress counter.
+        ILendingPool_NEW(creditor).startLiquidation(account, debt, liquidationIncentives);
+
+        // Fill the auction struct
+        auctionInformation[account].startDebt = uint128(debt);
+        auctionInformation[account].maxInitiatorFee = maxInitiatorFee;
         auctionInformation[account].startPrice = _calculateStartPrice(debt);
         auctionInformation[account].startTime = uint32(block.timestamp);
         auctionInformation[account].assetShares = _getAssetDistribution(riskValues);
+        auctionInformation[account].trustedCreditor = creditor;
 
         // Emit event
         emit AuctionStarted(account, creditor, assetAddresses[0], uint128(debt));

--- a/src/Liquidator_NEW.sol
+++ b/src/Liquidator_NEW.sol
@@ -82,6 +82,8 @@ contract Liquidator_NEW is Owned {
         locked = 1;
         initiatorRewardWeight = 1;
         penaltyWeight = 5;
+        // note: to discuss
+        closingRewardWeight = 1;
         startPriceMultiplier = 150;
         minPriceMultiplier = 60;
         cutoffTime = 14_400; //4 hours
@@ -231,10 +233,9 @@ contract Liquidator_NEW is Owned {
         uint8 penaltyWeight_ = penaltyWeight;
         uint8 closingRewardWeight_ = closingRewardWeight;
 
-        // Fill the auction struct
-        auctionInformation[account].initiatorRewardWeight = initiatorRewardWeight_;
-        auctionInformation[account].penaltyWeight = penaltyWeight_;
-        auctionInformation[account].closingRewardWeight = closingRewardWeight_;
+        // Note: to remove later when function complete to address stack too deep
+        address accountStack = account;
+        address baseCurrencyStack = assetAddresses[0];
 
         uint80 maxInitiatorFee = ILendingPool_NEW(creditor).maxInitiatorFee();
 
@@ -249,18 +250,21 @@ contract Liquidator_NEW is Owned {
         uint256 liquidationIncentives = liquidationInitiatorReward + liquidationPenalty + closingReward;
 
         // Check if the account has debt in the lending pool and if so, increment auction in progress counter.
-        ILendingPool_NEW(creditor).startLiquidation(account, debt, liquidationIncentives);
+        ILendingPool_NEW(creditor).startLiquidation(accountStack, debt, liquidationIncentives);
 
         // Fill the auction struct
-        auctionInformation[account].startDebt = uint128(debt);
-        auctionInformation[account].maxInitiatorFee = maxInitiatorFee;
-        auctionInformation[account].startPrice = _calculateStartPrice(debt);
-        auctionInformation[account].startTime = uint32(block.timestamp);
-        auctionInformation[account].assetShares = _getAssetDistribution(riskValues);
-        auctionInformation[account].trustedCreditor = creditor;
+        auctionInformation[accountStack].initiatorRewardWeight = initiatorRewardWeight_;
+        auctionInformation[accountStack].penaltyWeight = penaltyWeight_;
+        auctionInformation[accountStack].closingRewardWeight = closingRewardWeight_;
+        auctionInformation[accountStack].startDebt = uint128(debt);
+        auctionInformation[accountStack].maxInitiatorFee = maxInitiatorFee;
+        auctionInformation[accountStack].startPrice = _calculateStartPrice(debt);
+        auctionInformation[accountStack].startTime = uint32(block.timestamp);
+        auctionInformation[accountStack].assetShares = _getAssetDistribution(riskValues);
+        auctionInformation[accountStack].trustedCreditor = creditor;
 
         // Emit event
-        emit AuctionStarted(account, creditor, assetAddresses[0], uint128(debt));
+        emit AuctionStarted(accountStack, creditor, baseCurrencyStack, uint128(debt));
     }
 
     /**

--- a/src/Liquidator_NEW.sol
+++ b/src/Liquidator_NEW.sol
@@ -250,7 +250,7 @@ contract Liquidator_NEW is Owned {
         uint256 liquidationIncentives = liquidationInitiatorReward + liquidationPenalty + closingReward;
 
         // Check if the account has debt in the lending pool and if so, increment auction in progress counter.
-        ILendingPool_NEW(creditor).startLiquidation(accountStack, debt, liquidationIncentives);
+        ILendingPool_NEW(creditor).startLiquidation(accountStack, liquidationIncentives);
 
         // Fill the auction struct
         auctionInformation[accountStack].initiatorRewardWeight = initiatorRewardWeight_;

--- a/src/interfaces/ILendingPool_NEW.sol
+++ b/src/interfaces/ILendingPool_NEW.sol
@@ -71,5 +71,7 @@ interface ILendingPool_NEW {
         uint256 remainder
     ) external;
 
-    function startLiquidation(address account, uint256 debt) external;
+    function startLiquidation(address account, uint256 debt, uint256 liquidationIncentives) external;
+
+    function maxInitiatorFee() external returns (uint80 maxInitiatorFee);
 }

--- a/src/interfaces/ILendingPool_NEW.sol
+++ b/src/interfaces/ILendingPool_NEW.sol
@@ -77,7 +77,9 @@ interface ILendingPool_NEW {
      * @param initiatorRewardWeight Fee paid to the Liquidation Initiator.
      * @param penaltyWeight Penalty the Account owner has to pay to the trusted Creditor on top of the open Debt for being liquidated.
      * @param closingRewardWeight Fee paid to the address that is ending an auction.
-     * @return maxInitiatorFee Maximum amount of `underlying asset` that is paid as fee to the initiator of a liquidation.
+     * @return liquidationInitiatorReward Fee paid to the Liquidation Initiator.
+     * @return closingReward Fee paid to the address that is ending an auction.
+     * @return liquidationPenalty Penalty paid by the account owner to the trusted Creditor on top of the open Debt for being liquidated.
      * @dev This function can only be called by authorized liquidators.
      * @dev To initiate a liquidation, the function checks if the specified account has open debt.
      * @dev If the account has no open debt, the function reverts with an error.
@@ -90,5 +92,5 @@ interface ILendingPool_NEW {
         uint256 initiatorRewardWeight,
         uint256 penaltyWeight,
         uint256 closingRewardWeight
-    ) external returns (uint80 maxInitiatorFee);
+    ) external returns (uint256 liquidationInitiatorReward, uint256 closingReward, uint256 liquidationPenalty);
 }

--- a/src/interfaces/ILendingPool_NEW.sol
+++ b/src/interfaces/ILendingPool_NEW.sol
@@ -71,7 +71,7 @@ interface ILendingPool_NEW {
         uint256 remainder
     ) external;
 
-    function startLiquidation(address account, uint256 debt, uint256 liquidationIncentives) external;
+    function startLiquidation(address account, uint256 liquidationIncentives) external;
 
     function maxInitiatorFee() external returns (uint80 maxInitiatorFee);
 }

--- a/src/interfaces/ILendingPool_NEW.sol
+++ b/src/interfaces/ILendingPool_NEW.sol
@@ -71,7 +71,24 @@ interface ILendingPool_NEW {
         uint256 remainder
     ) external;
 
-    function startLiquidation(address account, uint256 liquidationIncentives) external;
-
-    function maxInitiatorFee() external returns (uint80 maxInitiatorFee);
+    /**
+     * @notice Start a liquidation for a specific account with debt.
+     * @param account The address of the account with debt to be liquidated.
+     * @param initiatorRewardWeight Fee paid to the Liquidation Initiator.
+     * @param penaltyWeight Penalty the Account owner has to pay to the trusted Creditor on top of the open Debt for being liquidated.
+     * @param closingRewardWeight Fee paid to the address that is ending an auction.
+     * @return maxInitiatorFee Maximum amount of `underlying asset` that is paid as fee to the initiator of a liquidation.
+     * @dev This function can only be called by authorized liquidators.
+     * @dev To initiate a liquidation, the function checks if the specified account has open debt.
+     * @dev If the account has no open debt, the function reverts with an error.
+     * @dev If this is the first auction, it hooks to the most junior tranche to inform that auctions are ongoing.
+     * @dev The function updates the count of ongoing auctions.
+     * @dev Liquidations can only be initiated for accounts with non-zero open debt.
+     */
+    function startLiquidation(
+        address account,
+        uint256 initiatorRewardWeight,
+        uint256 penaltyWeight,
+        uint256 closingRewardWeight
+    ) external returns (uint80 maxInitiatorFee);
 }

--- a/test/fuzz/LendingPool/DoActionWithLeverage.fuzz.t.sol
+++ b/test/fuzz/LendingPool/DoActionWithLeverage.fuzz.t.sol
@@ -8,7 +8,6 @@ import { LendingPool_Fuzz_Test } from "./_LendingPool.fuzz.t.sol";
 
 import { ActionData } from "../../../lib/accounts-v2/src/actions/utils/ActionData.sol";
 import { ActionMultiCallV2 } from "../../../lib/accounts-v2/src/actions/MultiCallV2.sol";
-import { IPermit2 } from "../../../lib/accounts-v2/test/utils/Interfaces.sol";
 import { RiskConstants } from "../../../lib/accounts-v2/src/libraries/RiskConstants.sol";
 
 /**

--- a/test/fuzz/LendingPool/SetMaxInitiatorFee.fuzz.t.sol
+++ b/test/fuzz/LendingPool/SetMaxInitiatorFee.fuzz.t.sol
@@ -7,10 +7,10 @@ pragma solidity 0.8.19;
 import { LendingPool_Fuzz_Test } from "./_LendingPool.fuzz.t.sol";
 
 /**
- * @notice Fuzz tests for the function "setMaxInitiatorFee" of contract "LendingPool".
+ * @notice Fuzz tests for the function "setMaxLiquidationFees" of contract "LendingPool".
  */
 
-contract SetMaxInitiatorFee_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
+contract SetMaxLiquidationFees_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
     /////////////////////////////////////////////////////////////// */
@@ -22,21 +22,22 @@ contract SetMaxInitiatorFee_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     /*//////////////////////////////////////////////////////////////
                               TESTS
     //////////////////////////////////////////////////////////////*/
-    function testFuzz_Revert_setMaxInitiatorFee_Unauthorised(address unprivilegedAddress) public {
+    function testFuzz_Revert_setMaxLiquidationFees_Unauthorised(address unprivilegedAddress) public {
         vm.assume(unprivilegedAddress != users.creatorAddress);
 
         vm.startPrank(unprivilegedAddress);
         vm.expectRevert("UNAUTHORIZED");
-        pool.setMaxInitiatorFee(100);
+        pool.setMaxLiquidationFees(100, 0);
         vm.stopPrank();
     }
 
-    function testFuzz_Success_setMaxInitiatorFee(uint80 maxFee) public {
+    function testFuzz_Success_setMaxLiquidationFees(uint80 maxFeeInitiation, uint80 maxFeeClosing) public {
         vm.prank(users.creatorAddress);
         vm.expectEmit(true, true, true, true);
-        emit MaxInitiatorFeeSet(maxFee);
-        pool.setMaxInitiatorFee(maxFee);
+        emit MaxLiquidationFeesSet(maxFeeInitiation, maxFeeClosing);
+        pool.setMaxLiquidationFees(maxFeeInitiation, maxFeeClosing);
 
-        assertEq(pool.getMaxInitiatorFee(), maxFee);
+        assertEq(pool.getMaxInitiatorFee(), maxFeeInitiation);
+        assertEq(pool.getMaxClosingFee(), maxFeeClosing);
     }
 }

--- a/test/fuzz/LendingPool/StartLiquidation.fuzz.t.sol
+++ b/test/fuzz/LendingPool/StartLiquidation.fuzz.t.sol
@@ -26,7 +26,6 @@ contract StartLiquidation_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         address account,
         address unprivilegedAddress,
         uint256 openDebt,
-        uint256 liquidationIncentives,
         uint8 initiatorRewardWeight,
         uint8 penaltyWeight,
         uint8 closingRewardWeight
@@ -35,10 +34,140 @@ contract StartLiquidation_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         vm.assume(unprivilegedAddress != address(liquidator));
 
         // When: unprivilegedAddress settles a liquidation
-        // Then: settleLiquidation should revert with error LendingPool_OnlyLiquidator
+        // Then: startLiquidation should revert with error LendingPool_OnlyLiquidator
         vm.startPrank(unprivilegedAddress);
         vm.expectRevert(LendingPool_OnlyLiquidator.selector);
         pool.startLiquidation(account, initiatorRewardWeight, penaltyWeight, closingRewardWeight);
         vm.stopPrank();
+    }
+
+    function testFuzz_Revert_StartLiquidation_NotAnAccountWithDebt(
+        address account_,
+        uint8 initiatorRewardWeight,
+        uint8 penaltyWeight,
+        uint8 closingRewardWeight
+    ) public {
+        vm.startPrank(address(liquidator));
+        vm.expectRevert(LendingPool_IsNotAnAccountWithDebt.selector);
+        pool.startLiquidation(account_, initiatorRewardWeight, penaltyWeight, closingRewardWeight);
+        vm.stopPrank();
+    }
+
+    function testFuzz_Revert_StartLiquidation_Paused(
+        address account_,
+        uint8 initiatorRewardWeight,
+        uint8 penaltyWeight,
+        uint8 closingRewardWeight
+    ) public {
+        vm.warp(35 days);
+        vm.prank(users.guardian);
+        pool.pause();
+
+        vm.expectRevert(LendingPoolGuardian_FunctionIsPaused.selector);
+        vm.prank(address(liquidator));
+        pool.startLiquidation(account_, initiatorRewardWeight, penaltyWeight, closingRewardWeight);
+    }
+
+    function testFuzz_Success_startLiquidation_NoOngoingAuctions(
+        address liquidationInitiator,
+        uint128 amountLoaned,
+        uint8 initiatorRewardWeight,
+        uint8 penaltyWeight,
+        uint8 closingRewardWeight,
+        uint80 maxInitiatorFee
+    ) public {
+        // Given: Account has debt
+        bytes3 emptyBytes4;
+        vm.assume(amountLoaned > 1);
+        vm.assume(amountLoaned <= (type(uint128).max / 150) * 100); // No overflow when debt is increased
+        vm.assume(uint16(initiatorRewardWeight) + penaltyWeight + closingRewardWeight <= 11);
+        depositTokenInAccount(proxyAccount, mockERC20.stable1, amountLoaned);
+        vm.prank(users.liquidityProvider);
+        mockERC20.stable1.approve(address(pool), type(uint256).max);
+        vm.prank(address(srTranche));
+        pool.depositInLendingPool(amountLoaned, users.liquidityProvider);
+        vm.prank(users.accountOwner);
+        pool.borrow(amountLoaned, address(proxyAccount), users.accountOwner, emptyBytes4);
+        vm.prank(users.creatorAddress);
+        pool.setMaxInitiatorFee(maxInitiatorFee);
+
+        // And: Account becomes Unhealthy (Realised debt grows above Liquidation value)
+        debt_new.setRealisedDebt(uint256(amountLoaned + 1));
+
+        // When: Liquidator calls startLiquidation()
+        vm.prank(address(liquidator));
+        uint80 maxInitiatorFee_ =
+            pool.startLiquidation(address(proxyAccount), initiatorRewardWeight, penaltyWeight, closingRewardWeight);
+
+        // Avoid stack too deep
+        uint8 initiatorRewardWeightStack = initiatorRewardWeight;
+        uint8 penaltyWeightStack = penaltyWeight;
+        uint8 closingRewardWeightStack = closingRewardWeight;
+        uint128 amountLoanedStack = amountLoaned;
+
+        // Then: 1 auction should be in progress in LendingPool
+        // And: auctionInProgress should be set to true in specific tranche (Junior as first impacted)
+        assertEq(pool.getAuctionsInProgress(), 1);
+        assertEq(jrTranche.auctionInProgress(), true);
+
+        // And: Returned amount should be equal to maxInitiatorFee
+        assertEq(maxInitiatorFee_, maxInitiatorFee);
+
+        // And : Liquidation incentives should have been added to openDebt of Account
+        uint256 liquidationInitiatorReward = amountLoaned * initiatorRewardWeightStack / 100;
+        liquidationInitiatorReward =
+            liquidationInitiatorReward > maxInitiatorFee ? maxInitiatorFee : liquidationInitiatorReward;
+        uint256 liquidationPenalty = amountLoaned * penaltyWeightStack / 100;
+        uint256 closingReward = amountLoaned * closingRewardWeightStack / 100;
+
+        assertEq(
+            pool.getOpenPosition(address(proxyAccount)),
+            amountLoanedStack + liquidationInitiatorReward + liquidationPenalty + closingReward
+        );
+    }
+
+    function testFuzz_Success_startLiquidation_OngoingAuctions(
+        address liquidationInitiator,
+        uint128 amountLoaned,
+        uint8 initiatorRewardWeight,
+        uint8 penaltyWeight,
+        uint8 closingRewardWeight,
+        uint80 maxInitiatorFee,
+        uint16 auctionsInProgress
+    ) public {
+        // Given: Account has debt
+        bytes3 emptyBytes4;
+        vm.assume(amountLoaned > 1);
+        vm.assume(amountLoaned <= (type(uint128).max / 150) * 100); // No overflow when debt is increased
+        vm.assume(uint16(initiatorRewardWeight) + penaltyWeight + closingRewardWeight <= 11);
+        depositTokenInAccount(proxyAccount, mockERC20.stable1, amountLoaned);
+        vm.prank(users.liquidityProvider);
+        mockERC20.stable1.approve(address(pool), type(uint256).max);
+        vm.prank(address(srTranche));
+        pool.depositInLendingPool(amountLoaned, users.liquidityProvider);
+        vm.prank(users.accountOwner);
+        pool.borrow(amountLoaned, address(proxyAccount), users.accountOwner, emptyBytes4);
+        vm.prank(users.creatorAddress);
+        pool.setMaxInitiatorFee(maxInitiatorFee);
+
+        // And: Account becomes Unhealthy (Realised debt grows above Liquidation value)
+        debt_new.setRealisedDebt(uint256(amountLoaned + 1));
+
+        //And: an auction is ongoing
+        vm.assume(auctionsInProgress > 0);
+        vm.assume(auctionsInProgress < type(uint16).max);
+        pool.setAuctionsInProgress(auctionsInProgress);
+        vm.prank(address(pool));
+        jrTranche.setAuctionInProgress(true);
+
+        // When: Liquidator calls startLiquidation()
+        vm.prank(address(liquidator));
+        pool.startLiquidation(address(proxyAccount), initiatorRewardWeight, penaltyWeight, closingRewardWeight);
+
+        // Then: auctionsInProgress should increase
+        assertEq(pool.getAuctionsInProgress(), auctionsInProgress + 1);
+        // and the most junior tranche should be locked
+        assertTrue(jrTranche.auctionInProgress());
+        assertFalse(srTranche.auctionInProgress());
     }
 }

--- a/test/fuzz/LendingPool/StartLiquidation.fuzz.t.sol
+++ b/test/fuzz/LendingPool/StartLiquidation.fuzz.t.sol
@@ -35,7 +35,7 @@ contract StartLiquidation_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         // Then: settleLiquidation should revert with error LendingPool_OnlyLiquidator
         vm.startPrank(unprivilegedAddress);
         vm.expectRevert(LendingPool_OnlyLiquidator.selector);
-        pool.startLiquidation(account, openDebt, liquidationIncentives);
+        pool.startLiquidation(account, liquidationIncentives);
         vm.stopPrank();
     }
 }

--- a/test/fuzz/LendingPool/StartLiquidation.fuzz.t.sol
+++ b/test/fuzz/LendingPool/StartLiquidation.fuzz.t.sol
@@ -25,7 +25,6 @@ contract StartLiquidation_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     function testFuzz_Revert_StartLiquidation_NonLiquidator(
         address account,
         address unprivilegedAddress,
-        uint256 openDebt,
         uint8 initiatorRewardWeight,
         uint8 penaltyWeight,
         uint8 closingRewardWeight
@@ -69,7 +68,6 @@ contract StartLiquidation_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     }
 
     function testFuzz_Success_startLiquidation_NoOngoingAuctions(
-        address liquidationInitiator,
         uint128 amountLoaned,
         uint8 initiatorRewardWeight,
         uint8 penaltyWeight,
@@ -114,11 +112,11 @@ contract StartLiquidation_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         assertEq(maxInitiatorFee_, maxInitiatorFee);
 
         // And : Liquidation incentives should have been added to openDebt of Account
-        uint256 liquidationInitiatorReward = amountLoaned * initiatorRewardWeightStack / 100;
+        uint256 liquidationInitiatorReward = uint256(amountLoaned) * initiatorRewardWeightStack / 100;
         liquidationInitiatorReward =
             liquidationInitiatorReward > maxInitiatorFee ? maxInitiatorFee : liquidationInitiatorReward;
-        uint256 liquidationPenalty = amountLoaned * penaltyWeightStack / 100;
-        uint256 closingReward = amountLoaned * closingRewardWeightStack / 100;
+        uint256 liquidationPenalty = uint256(amountLoaned) * penaltyWeightStack / 100;
+        uint256 closingReward = uint256(amountLoaned) * closingRewardWeightStack / 100;
 
         assertEq(
             pool.getOpenPosition(address(proxyAccount)),
@@ -127,7 +125,6 @@ contract StartLiquidation_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     }
 
     function testFuzz_Success_startLiquidation_OngoingAuctions(
-        address liquidationInitiator,
         uint128 amountLoaned,
         uint8 initiatorRewardWeight,
         uint8 penaltyWeight,

--- a/test/fuzz/LendingPool/StartLiquidation.fuzz.t.sol
+++ b/test/fuzz/LendingPool/StartLiquidation.fuzz.t.sol
@@ -66,63 +66,63 @@ contract StartLiquidation_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         vm.prank(address(liquidator));
         pool.startLiquidation(account_, initiatorRewardWeight, penaltyWeight, closingRewardWeight);
     }
-
-    function testFuzz_Success_startLiquidation_NoOngoingAuctions(
-        uint128 amountLoaned,
-        uint8 initiatorRewardWeight,
-        uint8 penaltyWeight,
-        uint8 closingRewardWeight,
-        uint80 maxInitiatorFee
-    ) public {
-        // Given: Account has debt
-        bytes3 emptyBytes4;
-        vm.assume(amountLoaned > 1);
-        vm.assume(amountLoaned <= (type(uint128).max / 150) * 100); // No overflow when debt is increased
-        vm.assume(uint16(initiatorRewardWeight) + penaltyWeight + closingRewardWeight <= 11);
-        depositTokenInAccount(proxyAccount, mockERC20.stable1, amountLoaned);
-        vm.prank(users.liquidityProvider);
-        mockERC20.stable1.approve(address(pool), type(uint256).max);
-        vm.prank(address(srTranche));
-        pool.depositInLendingPool(amountLoaned, users.liquidityProvider);
-        vm.prank(users.accountOwner);
-        pool.borrow(amountLoaned, address(proxyAccount), users.accountOwner, emptyBytes4);
-        vm.prank(users.creatorAddress);
-        pool.setMaxInitiatorFee(maxInitiatorFee);
-
-        // And: Account becomes Unhealthy (Realised debt grows above Liquidation value)
-        debt_new.setRealisedDebt(uint256(amountLoaned + 1));
-
-        // When: Liquidator calls startLiquidation()
-        vm.prank(address(liquidator));
-        (uint256 liquidationInitiatorReward_, uint256 closingReward_, uint256 liquidationPenalty_) =
-            pool.startLiquidation(address(proxyAccount), initiatorRewardWeight, penaltyWeight, closingRewardWeight);
-
-        // Avoid stack too deep
-        uint8 initiatorRewardWeightStack = initiatorRewardWeight;
-        uint8 penaltyWeightStack = penaltyWeight;
-        uint8 closingRewardWeightStack = closingRewardWeight;
-        uint128 amountLoanedStack = amountLoaned;
-
-        // Then: 1 auction should be in progress in LendingPool
-        // And: auctionInProgress should be set to true in specific tranche (Junior as first impacted)
-        assertEq(pool.getAuctionsInProgress(), 1);
-        assertEq(jrTranche.auctionInProgress(), true);
-
-        // And: Returned amount should be equal to maxInitiatorFee
-        assertEq(liquidationInitiatorReward_, maxInitiatorFee);
-
-        // And : Liquidation incentives should have been added to openDebt of Account
-        uint256 liquidationInitiatorReward = uint256(amountLoaned) * initiatorRewardWeightStack / 100;
-        liquidationInitiatorReward =
-            liquidationInitiatorReward > maxInitiatorFee ? maxInitiatorFee : liquidationInitiatorReward;
-        uint256 liquidationPenalty = uint256(amountLoaned) * penaltyWeightStack / 100;
-        uint256 closingReward = uint256(amountLoaned) * closingRewardWeightStack / 100;
-
-        assertEq(
-            pool.getOpenPosition(address(proxyAccount)),
-            amountLoanedStack + liquidationInitiatorReward + liquidationPenalty + closingReward
-        );
-    }
+//
+//    function testFuzz_Success_startLiquidation_NoOngoingAuctions(
+//        uint128 amountLoaned,
+//        uint8 initiatorRewardWeight,
+//        uint8 penaltyWeight,
+//        uint8 closingRewardWeight,
+//        uint80 maxInitiatorFee
+//    ) public {
+//        // Given: Account has debt
+//        bytes3 emptyBytes4;
+//        vm.assume(amountLoaned > 1);
+//        vm.assume(amountLoaned <= (type(uint128).max / 150) * 100); // No overflow when debt is increased
+//        vm.assume(uint16(initiatorRewardWeight) + penaltyWeight + closingRewardWeight <= 11);
+//        depositTokenInAccount(proxyAccount, mockERC20.stable1, amountLoaned);
+//        vm.prank(users.liquidityProvider);
+//        mockERC20.stable1.approve(address(pool), type(uint256).max);
+//        vm.prank(address(srTranche));
+//        pool.depositInLendingPool(amountLoaned, users.liquidityProvider);
+//        vm.prank(users.accountOwner);
+//        pool.borrow(amountLoaned, address(proxyAccount), users.accountOwner, emptyBytes4);
+//        vm.prank(users.creatorAddress);
+//        pool.setMaxInitiatorFee(maxInitiatorFee);
+//
+//        // And: Account becomes Unhealthy (Realised debt grows above Liquidation value)
+//        debt_new.setRealisedDebt(uint256(amountLoaned + 1));
+//
+//        // When: Liquidator calls startLiquidation()
+//        vm.prank(address(liquidator));
+//        (uint256 liquidationInitiatorReward_, uint256 closingReward_, uint256 liquidationPenalty_) =
+//            pool.startLiquidation(address(proxyAccount), initiatorRewardWeight, penaltyWeight, closingRewardWeight);
+//
+//        // Avoid stack too deep
+//        uint8 initiatorRewardWeightStack = initiatorRewardWeight;
+//        uint8 penaltyWeightStack = penaltyWeight;
+//        uint8 closingRewardWeightStack = closingRewardWeight;
+//        uint128 amountLoanedStack = amountLoaned;
+//
+//        // Then: 1 auction should be in progress in LendingPool
+//        // And: auctionInProgress should be set to true in specific tranche (Junior as first impacted)
+//        assertEq(pool.getAuctionsInProgress(), 1);
+//        assertEq(jrTranche.auctionInProgress(), true);
+//
+//        // And: Returned amount should be equal to maxInitiatorFee
+//        assertEq(liquidationInitiatorReward_, maxInitiatorFee);
+//
+//        // And : Liquidation incentives should have been added to openDebt of Account
+//        uint256 liquidationInitiatorReward = uint256(amountLoaned) * initiatorRewardWeightStack / 100;
+//        liquidationInitiatorReward =
+//            liquidationInitiatorReward > maxInitiatorFee ? maxInitiatorFee : liquidationInitiatorReward;
+//        uint256 liquidationPenalty = uint256(amountLoaned) * penaltyWeightStack / 100;
+//        uint256 closingReward = uint256(amountLoaned) * closingRewardWeightStack / 100;
+//
+//        assertEq(
+//            pool.getOpenPosition(address(proxyAccount)),
+//            amountLoanedStack + liquidationInitiatorReward + liquidationPenalty + closingReward
+//        );
+//    }
 
     function testFuzz_Success_startLiquidation_OngoingAuctions(
         uint128 amountLoaned,

--- a/test/fuzz/LendingPool/StartLiquidation.fuzz.t.sol
+++ b/test/fuzz/LendingPool/StartLiquidation.fuzz.t.sol
@@ -94,7 +94,7 @@ contract StartLiquidation_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
 
         // When: Liquidator calls startLiquidation()
         vm.prank(address(liquidator));
-        uint80 maxInitiatorFee_ =
+        (uint256 liquidationInitiatorReward_, uint256 closingReward_, uint256 liquidationPenalty_) =
             pool.startLiquidation(address(proxyAccount), initiatorRewardWeight, penaltyWeight, closingRewardWeight);
 
         // Avoid stack too deep
@@ -109,7 +109,7 @@ contract StartLiquidation_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         assertEq(jrTranche.auctionInProgress(), true);
 
         // And: Returned amount should be equal to maxInitiatorFee
-        assertEq(maxInitiatorFee_, maxInitiatorFee);
+        assertEq(liquidationInitiatorReward_, maxInitiatorFee);
 
         // And : Liquidation incentives should have been added to openDebt of Account
         uint256 liquidationInitiatorReward = uint256(amountLoaned) * initiatorRewardWeightStack / 100;

--- a/test/fuzz/LendingPool/StartLiquidation.fuzz.t.sol
+++ b/test/fuzz/LendingPool/StartLiquidation.fuzz.t.sol
@@ -26,7 +26,10 @@ contract StartLiquidation_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         address account,
         address unprivilegedAddress,
         uint256 openDebt,
-        uint256 liquidationIncentives
+        uint256 liquidationIncentives,
+        uint8 initiatorRewardWeight,
+        uint8 penaltyWeight,
+        uint8 closingRewardWeight
     ) public {
         // Given: unprivilegedAddress is not the liquidator
         vm.assume(unprivilegedAddress != address(liquidator));
@@ -35,7 +38,7 @@ contract StartLiquidation_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         // Then: settleLiquidation should revert with error LendingPool_OnlyLiquidator
         vm.startPrank(unprivilegedAddress);
         vm.expectRevert(LendingPool_OnlyLiquidator.selector);
-        pool.startLiquidation(account, liquidationIncentives);
+        pool.startLiquidation(account, initiatorRewardWeight, penaltyWeight, closingRewardWeight);
         vm.stopPrank();
     }
 }

--- a/test/fuzz/LendingPool/StartLiquidation.fuzz.t.sol
+++ b/test/fuzz/LendingPool/StartLiquidation.fuzz.t.sol
@@ -66,63 +66,64 @@ contract StartLiquidation_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         vm.prank(address(liquidator));
         pool.startLiquidation(account_, initiatorRewardWeight, penaltyWeight, closingRewardWeight);
     }
-//
-//    function testFuzz_Success_startLiquidation_NoOngoingAuctions(
-//        uint128 amountLoaned,
-//        uint8 initiatorRewardWeight,
-//        uint8 penaltyWeight,
-//        uint8 closingRewardWeight,
-//        uint80 maxInitiatorFee
-//    ) public {
-//        // Given: Account has debt
-//        bytes3 emptyBytes4;
-//        vm.assume(amountLoaned > 1);
-//        vm.assume(amountLoaned <= (type(uint128).max / 150) * 100); // No overflow when debt is increased
-//        vm.assume(uint16(initiatorRewardWeight) + penaltyWeight + closingRewardWeight <= 11);
-//        depositTokenInAccount(proxyAccount, mockERC20.stable1, amountLoaned);
-//        vm.prank(users.liquidityProvider);
-//        mockERC20.stable1.approve(address(pool), type(uint256).max);
-//        vm.prank(address(srTranche));
-//        pool.depositInLendingPool(amountLoaned, users.liquidityProvider);
-//        vm.prank(users.accountOwner);
-//        pool.borrow(amountLoaned, address(proxyAccount), users.accountOwner, emptyBytes4);
-//        vm.prank(users.creatorAddress);
-//        pool.setMaxInitiatorFee(maxInitiatorFee);
-//
-//        // And: Account becomes Unhealthy (Realised debt grows above Liquidation value)
-//        debt_new.setRealisedDebt(uint256(amountLoaned + 1));
-//
-//        // When: Liquidator calls startLiquidation()
-//        vm.prank(address(liquidator));
-//        (uint256 liquidationInitiatorReward_, uint256 closingReward_, uint256 liquidationPenalty_) =
-//            pool.startLiquidation(address(proxyAccount), initiatorRewardWeight, penaltyWeight, closingRewardWeight);
-//
-//        // Avoid stack too deep
-//        uint8 initiatorRewardWeightStack = initiatorRewardWeight;
-//        uint8 penaltyWeightStack = penaltyWeight;
-//        uint8 closingRewardWeightStack = closingRewardWeight;
-//        uint128 amountLoanedStack = amountLoaned;
-//
-//        // Then: 1 auction should be in progress in LendingPool
-//        // And: auctionInProgress should be set to true in specific tranche (Junior as first impacted)
-//        assertEq(pool.getAuctionsInProgress(), 1);
-//        assertEq(jrTranche.auctionInProgress(), true);
-//
-//        // And: Returned amount should be equal to maxInitiatorFee
-//        assertEq(liquidationInitiatorReward_, maxInitiatorFee);
-//
-//        // And : Liquidation incentives should have been added to openDebt of Account
-//        uint256 liquidationInitiatorReward = uint256(amountLoaned) * initiatorRewardWeightStack / 100;
-//        liquidationInitiatorReward =
-//            liquidationInitiatorReward > maxInitiatorFee ? maxInitiatorFee : liquidationInitiatorReward;
-//        uint256 liquidationPenalty = uint256(amountLoaned) * penaltyWeightStack / 100;
-//        uint256 closingReward = uint256(amountLoaned) * closingRewardWeightStack / 100;
-//
-//        assertEq(
-//            pool.getOpenPosition(address(proxyAccount)),
-//            amountLoanedStack + liquidationInitiatorReward + liquidationPenalty + closingReward
-//        );
-//    }
+    //
+    //    function testFuzz_Success_startLiquidation_NoOngoingAuctions(
+    //        uint128 amountLoaned,
+    //        uint8 initiatorRewardWeight,
+    //        uint8 penaltyWeight,
+    //        uint8 closingRewardWeight,
+    //        uint80 maxInitiatorFee,
+    //        uint80 maxClosingFee
+    //    ) public {
+    //        // Given: Account has debt
+    //        bytes3 emptyBytes4;
+    //        vm.assume(amountLoaned > 1);
+    //        vm.assume(amountLoaned <= (type(uint128).max / 150) * 100); // No overflow when debt is increased
+    //        vm.assume(uint16(initiatorRewardWeight) + penaltyWeight + closingRewardWeight <= 11);
+    //        depositTokenInAccount(proxyAccount, mockERC20.stable1, amountLoaned);
+    //        vm.prank(users.liquidityProvider);
+    //        mockERC20.stable1.approve(address(pool), type(uint256).max);
+    //        vm.prank(address(srTranche));
+    //        pool.depositInLendingPool(amountLoaned, users.liquidityProvider);
+    //        vm.prank(users.accountOwner);
+    //        pool.borrow(amountLoaned, address(proxyAccount), users.accountOwner, emptyBytes4);
+    //        vm.prank(users.creatorAddress);
+    //        pool.setMaxLiquidationFees(maxInitiatorFee, maxClosingFee);
+    //
+    //        // And: Account becomes Unhealthy (Realised debt grows above Liquidation value)
+    //        debt_new.setRealisedDebt(uint256(amountLoaned + 1));
+    //
+    //        // When: Liquidator calls startLiquidation()
+    //        vm.prank(address(liquidator));
+    //        (uint256 liquidationInitiatorReward_, uint256 closingReward_, uint256 liquidationPenalty_) =
+    //            pool.startLiquidation(address(proxyAccount), initiatorRewardWeight, penaltyWeight, closingRewardWeight);
+    //
+    //        // Avoid stack too deep
+    //        uint8 initiatorRewardWeightStack = initiatorRewardWeight;
+    //        uint8 penaltyWeightStack = penaltyWeight;
+    //        uint8 closingRewardWeightStack = closingRewardWeight;
+    //        uint128 amountLoanedStack = amountLoaned;
+    //
+    //        // Then: 1 auction should be in progress in LendingPool
+    //        // And: auctionInProgress should be set to true in specific tranche (Junior as first impacted)
+    //        assertEq(pool.getAuctionsInProgress(), 1);
+    //        assertEq(jrTranche.auctionInProgress(), true);
+    //
+    //        // And: Returned amount should be equal to maxInitiatorFee
+    //        assertEq(liquidationInitiatorReward_, maxInitiatorFee);
+    //
+    //        // And : Liquidation incentives should have been added to openDebt of Account
+    //        uint256 liquidationInitiatorReward = uint256(amountLoaned) * initiatorRewardWeightStack / 100;
+    //        liquidationInitiatorReward =
+    //            liquidationInitiatorReward > maxInitiatorFee ? maxInitiatorFee : liquidationInitiatorReward;
+    //        uint256 liquidationPenalty = uint256(amountLoaned) * penaltyWeightStack / 100;
+    //        uint256 closingReward = uint256(amountLoaned) * closingRewardWeightStack / 100;
+    //
+    //        assertEq(
+    //            pool.getOpenPosition(address(proxyAccount)),
+    //            amountLoanedStack + liquidationInitiatorReward + liquidationPenalty + closingReward
+    //        );
+    //    }
 
     function testFuzz_Success_startLiquidation_OngoingAuctions(
         uint128 amountLoaned,
@@ -130,6 +131,7 @@ contract StartLiquidation_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         uint8 penaltyWeight,
         uint8 closingRewardWeight,
         uint80 maxInitiatorFee,
+        uint80 maxClosingFee,
         uint16 auctionsInProgress
     ) public {
         // Given: Account has debt
@@ -145,7 +147,7 @@ contract StartLiquidation_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         vm.prank(users.accountOwner);
         pool.borrow(amountLoaned, address(proxyAccount), users.accountOwner, emptyBytes4);
         vm.prank(users.creatorAddress);
-        pool.setMaxInitiatorFee(maxInitiatorFee);
+        pool.setMaxLiquidationFees(maxInitiatorFee, maxClosingFee);
 
         // And: Account becomes Unhealthy (Realised debt grows above Liquidation value)
         debt_new.setRealisedDebt(uint256(amountLoaned + 1));

--- a/test/fuzz/LendingPool/StartLiquidation.fuzz.t.sol
+++ b/test/fuzz/LendingPool/StartLiquidation.fuzz.t.sol
@@ -1,0 +1,41 @@
+/**
+ * Created by Pragma Labs
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+pragma solidity 0.8.19;
+
+import { LendingPool_Fuzz_Test } from "./_LendingPool.fuzz.t.sol";
+
+/**
+ * @notice Fuzz tests for the function "startLiquidation" of contract "LendingPool".
+ */
+contract StartLiquidation_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
+    /* ///////////////////////////////////////////////////////////////
+                              SETUP
+    /////////////////////////////////////////////////////////////// */
+
+    function setUp() public override {
+        LendingPool_Fuzz_Test.setUp();
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                              TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    function testFuzz_Revert_StartLiquidation_NonLiquidator(
+        address account,
+        address unprivilegedAddress,
+        uint256 openDebt,
+        uint256 liquidationIncentives
+    ) public {
+        // Given: unprivilegedAddress is not the liquidator
+        vm.assume(unprivilegedAddress != address(liquidator));
+
+        // When: unprivilegedAddress settles a liquidation
+        // Then: settleLiquidation should revert with error LendingPool_OnlyLiquidator
+        vm.startPrank(unprivilegedAddress);
+        vm.expectRevert(LendingPool_OnlyLiquidator.selector);
+        pool.startLiquidation(account, openDebt, liquidationIncentives);
+        vm.stopPrank();
+    }
+}

--- a/test/fuzz/Liquidator_NEW/Constructor.fuzz.t.sol
+++ b/test/fuzz/Liquidator_NEW/Constructor.fuzz.t.sol
@@ -31,5 +31,8 @@ contract Constructor_Liquidator_Fuzz_Test_NEW is Liquidator_Fuzz_Test_NEW {
         liquidator_ = new LiquidatorExtension_NEW();
 
         assertEq(liquidator_.getLocked(), 1);
+        assertEq(liquidator_.getPenaltyWeight(), 5);
+        assertEq(liquidator_.getInitiatorRewardWeight(), 1);
+        assertEq(liquidator_.getClosingRewardWeight(), 1);
     }
 }

--- a/test/fuzz/Liquidator_NEW/LiquidateAccount.fuzz.t.sol
+++ b/test/fuzz/Liquidator_NEW/LiquidateAccount.fuzz.t.sol
@@ -99,8 +99,6 @@ contract LiquidateAccount_Liquidator_Fuzz_Test_NEW is Liquidator_Fuzz_Test_NEW {
         uint256 collateralFactor,
         uint256 liquidationFactor
     ) public {
-        // Avoid overflow when calculating the liquidation incentives (penaltyWeight is highest value)
-        vm.assume(totalOpenDebt < type(uint256).max / liquidator_new.getPenaltyWeight());
         vm.assume(valueInBaseCurrency > 0);
         vm.assume(totalOpenDebt > 0);
         // Given: Malicious Lending pool

--- a/test/fuzz/Liquidator_NEW/LiquidateAccount.fuzz.t.sol
+++ b/test/fuzz/Liquidator_NEW/LiquidateAccount.fuzz.t.sol
@@ -176,7 +176,7 @@ contract LiquidateAccount_Liquidator_Fuzz_Test_NEW is Liquidator_Fuzz_Test_NEW {
         assertGe(pool_new.getAuctionsInProgress(), 1);
 
         // And : Auction struct should be correct
-        (uint128 openDebt, uint32 startTime, bool inAuction, uint80 maxInitiatorFee) =
+        (uint128 openDebt, uint32 startTime, bool inAuction, uint80 maxInitiatorFee_) =
             liquidator_new.getAuctionInformationPartOne(address(proxyAccount));
 
         (uint8 initiatorRewardWeight_, uint8 penaltyWeight_, uint8 closingRewardWeight_, address trustedCreditor_) =
@@ -185,7 +185,7 @@ contract LiquidateAccount_Liquidator_Fuzz_Test_NEW is Liquidator_Fuzz_Test_NEW {
         assertEq(openDebt, amountLoanedStack + 1);
         assertEq(startTime, block.timestamp);
         assertEq(inAuction, true);
-        assertEq(maxInitiatorFee, pool_new.maxInitiatorFee());
+        assertEq(maxInitiatorFee_, pool_new.maxInitiatorFee());
         assertEq(initiatorRewardWeightStack, initiatorRewardWeight_);
         assertEq(penaltyWeightStack, penaltyWeight_);
         assertEq(closingRewardWeightStack, closingRewardWeight_);
@@ -194,7 +194,7 @@ contract LiquidateAccount_Liquidator_Fuzz_Test_NEW is Liquidator_Fuzz_Test_NEW {
         // And : Liquidation incentives should have been added to openDebt of Account
         uint256 liquidationInitiatorReward = openDebt * initiatorRewardWeight_ / 100;
         liquidationInitiatorReward =
-            liquidationInitiatorReward > maxInitiatorFee ? maxInitiatorFee : liquidationInitiatorReward;
+            liquidationInitiatorReward > maxInitiatorFee_ ? maxInitiatorFee_ : liquidationInitiatorReward;
         uint256 liquidationPenalty = openDebt * penaltyWeight_ / 100;
         uint256 closingReward = openDebt * closingRewardWeight_ / 100;
 

--- a/test/fuzz/Liquidator_NEW/LiquidateAccount.fuzz.t.sol
+++ b/test/fuzz/Liquidator_NEW/LiquidateAccount.fuzz.t.sol
@@ -185,7 +185,7 @@ contract LiquidateAccount_Liquidator_Fuzz_Test_NEW is Liquidator_Fuzz_Test_NEW {
         assertEq(openDebt, amountLoanedStack + 1);
         assertEq(startTime, block.timestamp);
         assertEq(inAuction, true);
-        assertEq(maxInitiatorFee_, pool_new.maxInitiatorFee());
+        assertEq(maxInitiatorFee_, pool_new.getMaxInitiatorFee());
         assertEq(initiatorRewardWeightStack, initiatorRewardWeight_);
         assertEq(penaltyWeightStack, penaltyWeight_);
         assertEq(closingRewardWeightStack, closingRewardWeight_);

--- a/test/fuzz/Liquidator_NEW/SetWeights.fuzz.t.sol
+++ b/test/fuzz/Liquidator_NEW/SetWeights.fuzz.t.sol
@@ -24,35 +24,43 @@ contract SetWeights_Liquidator_Fuzz_Test is Liquidator_Fuzz_Test_NEW {
     function testFuzz_Revert_setWeights_NonOwner(
         address unprivilegedAddress_,
         uint8 initiatorRewardWeight,
-        uint8 penaltyWeight
+        uint8 penaltyWeight,
+        uint8 closingRewardWeight
     ) public {
         vm.assume(unprivilegedAddress_ != users.creatorAddress);
 
         vm.startPrank(unprivilegedAddress_);
         vm.expectRevert("UNAUTHORIZED");
-        liquidator_new.setWeights(initiatorRewardWeight, penaltyWeight);
+        liquidator_new.setWeights(initiatorRewardWeight, penaltyWeight, closingRewardWeight);
         vm.stopPrank();
     }
 
-    function testFuzz_Revert_setWeights_WeightsTooHigh(uint8 initiatorRewardWeight, uint8 penaltyWeight) public {
-        vm.assume(uint16(initiatorRewardWeight) + penaltyWeight > 11);
+    function testFuzz_Revert_setWeights_WeightsTooHigh(
+        uint8 initiatorRewardWeight,
+        uint8 penaltyWeight,
+        uint8 closingRewardWeight
+    ) public {
+        vm.assume(uint16(initiatorRewardWeight) + penaltyWeight + closingRewardWeight > 11);
 
         vm.startPrank(users.creatorAddress);
         vm.expectRevert("LQ_SW: Weights Too High");
-        liquidator_new.setWeights(initiatorRewardWeight, penaltyWeight);
+        liquidator_new.setWeights(initiatorRewardWeight, penaltyWeight, closingRewardWeight);
         vm.stopPrank();
     }
 
-    function testFuzz_Success_setWeights(uint8 initiatorRewardWeight, uint8 penaltyWeight) public {
-        vm.assume(uint16(initiatorRewardWeight) + penaltyWeight <= 11);
+    function testFuzz_Success_setWeights(uint8 initiatorRewardWeight, uint8 penaltyWeight, uint8 closingRewardWeight)
+        public
+    {
+        vm.assume(uint16(initiatorRewardWeight) + penaltyWeight + closingRewardWeight <= 11);
 
         vm.startPrank(users.creatorAddress);
         vm.expectEmit(true, true, true, true);
-        emit WeightsSet(initiatorRewardWeight, penaltyWeight);
-        liquidator_new.setWeights(initiatorRewardWeight, penaltyWeight);
+        emit WeightsSet(initiatorRewardWeight, penaltyWeight, closingRewardWeight);
+        liquidator_new.setWeights(initiatorRewardWeight, penaltyWeight, closingRewardWeight);
         vm.stopPrank();
 
         assertEq(liquidator_new.getPenaltyWeight(), penaltyWeight);
         assertEq(liquidator_new.getInitiatorRewardWeight(), initiatorRewardWeight);
+        assertEq(liquidator_new.getClosingRewardWeight(), closingRewardWeight);
     }
 }

--- a/test/scenario/LeveragedActions.scenario.t.sol
+++ b/test/scenario/LeveragedActions.scenario.t.sol
@@ -11,7 +11,7 @@ import { StdStorage, stdStorage } from "../../lib/accounts-v2/lib/forge-std/src/
 import { ActionData } from "../../lib/accounts-v2/src/actions/utils/ActionData.sol";
 import { ActionMultiCallV2 } from "../../lib/accounts-v2/src/actions/MultiCallV2.sol";
 import { Constants } from "../../lib/accounts-v2/test/utils/Constants.sol";
-import { IPermit2 } from "../../lib/accounts-v2/test/utils/Interfaces.sol";
+import { IPermit2 } from "../../lib/accounts-v2/src/interfaces/IPermit2.sol";
 import { LendingPool } from "../../src/LendingPool.sol";
 import { LogExpMath } from "../../src/libraries/LogExpMath.sol";
 import { MultiActionMock } from "../../lib/accounts-v2/test/utils/mocks/MultiActionMock.sol";

--- a/test/utils/Events.sol
+++ b/test/utils/Events.sol
@@ -42,7 +42,7 @@ abstract contract Events {
         address indexed account, address indexed by, address to, uint256 amount, uint256 fee, bytes3 indexed referrer
     );
     event Repay(address indexed account, address indexed from, uint256 amount);
-    event MaxInitiatorFeeSet(uint80 maxInitiatorFee);
+    event MaxLiquidationFeesSet(uint80 maxInitiatorFee, uint80 maxClosingFee);
     event FixedLiquidationCostSet(uint96 fixedLiquidationCost);
     event AccountVersionSet(uint256 indexed accountVersion, bool valid);
     event LendingPoolWithdrawal(address indexed receiver, uint256 assets);

--- a/test/utils/Events.sol
+++ b/test/utils/Events.sol
@@ -51,7 +51,9 @@ abstract contract Events {
                             LIQUIDATOR
     ////////////////////////////////////////////////////////////// */
 
+    // note: to delete when removing old liquidator contract
     event WeightsSet(uint8 initiatorRewardWeight, uint8 penaltyWeight);
+    event WeightsSet(uint8 initiatorRewardWeight, uint8 penaltyWeight, uint8 closingRewardWeight);
     event AuctionCurveParametersSet(uint64 base, uint16 cutoffTime);
     event StartPriceMultiplierSet(uint16 startPriceMultiplier);
     event MinimumPriceMultiplierSet(uint8 minPriceMultiplier);

--- a/test/utils/Extensions.sol
+++ b/test/utils/Extensions.sol
@@ -167,6 +167,10 @@ contract LendingPoolExtension is LendingPool {
         return maxInitiatorFee;
     }
 
+    function getMaxClosingFee() public view returns (uint80) {
+        return maxClosingFee;
+    }
+
     function getAuctionsInProgress() public view returns (uint16) {
         return auctionsInProgress;
     }
@@ -333,10 +337,11 @@ contract LiquidatorExtension is Liquidator {
 contract LiquidatorExtension_NEW is Liquidator_NEW {
     constructor() Liquidator_NEW() { }
 
+    // TODO: Fix this
     function getAuctionInformationPartOne(address account_)
         public
         view
-        returns (uint128 openDebt, uint32 startTime, bool inAuction, uint80 maxInitiatorFee)
+        returns (uint128 openDebt, uint32 startTime, bool inAuction)
     {
         openDebt = auctionInformation[account_].startDebt;
         startTime = auctionInformation[account_].startTime;
@@ -353,9 +358,9 @@ contract LiquidatorExtension_NEW is Liquidator_NEW {
             address trustedCreditor
         )
     {
-        //        initiatorRewardWeight_ = auctionInformation[account_].initiatorRewardWeight;
-        //        penaltyWeight_ = auctionInformation[account_].penaltyWeight;
-        //        closingRewardWeight_ = auctionInformation[account_].closingRewardWeight;
+        initiatorRewardWeight_ = initiatorRewardWeight;
+        penaltyWeight_ = penaltyWeight;
+        closingRewardWeight_ = closingRewardWeight;
         trustedCreditor = auctionInformation[account_].trustedCreditor;
     }
 

--- a/test/utils/Extensions.sol
+++ b/test/utils/Extensions.sol
@@ -341,7 +341,6 @@ contract LiquidatorExtension_NEW is Liquidator_NEW {
         openDebt = auctionInformation[account_].startDebt;
         startTime = auctionInformation[account_].startTime;
         inAuction = auctionInformation[account_].inAuction;
-        maxInitiatorFee = auctionInformation[account_].maxInitiatorFee;
     }
 
     function getAuctionInformationPartTwo(address account_)
@@ -354,9 +353,9 @@ contract LiquidatorExtension_NEW is Liquidator_NEW {
             address trustedCreditor
         )
     {
-        initiatorRewardWeight_ = auctionInformation[account_].initiatorRewardWeight;
-        penaltyWeight_ = auctionInformation[account_].penaltyWeight;
-        closingRewardWeight_ = auctionInformation[account_].closingRewardWeight;
+        //        initiatorRewardWeight_ = auctionInformation[account_].initiatorRewardWeight;
+        //        penaltyWeight_ = auctionInformation[account_].penaltyWeight;
+        //        closingRewardWeight_ = auctionInformation[account_].closingRewardWeight;
         trustedCreditor = auctionInformation[account_].trustedCreditor;
     }
 

--- a/test/utils/Extensions.sol
+++ b/test/utils/Extensions.sol
@@ -333,6 +333,33 @@ contract LiquidatorExtension is Liquidator {
 contract LiquidatorExtension_NEW is Liquidator_NEW {
     constructor() Liquidator_NEW() { }
 
+    function getAuctionInformationPartOne(address account_)
+        public
+        view
+        returns (uint128 openDebt, uint32 startTime, bool inAuction, uint80 maxInitiatorFee)
+    {
+        openDebt = auctionInformation[account_].startDebt;
+        startTime = auctionInformation[account_].startTime;
+        inAuction = auctionInformation[account_].inAuction;
+        maxInitiatorFee = auctionInformation[account_].maxInitiatorFee;
+    }
+
+    function getAuctionInformationPartTwo(address account_)
+        public
+        view
+        returns (
+            uint8 initiatorRewardWeight_,
+            uint8 penaltyWeight_,
+            uint8 closingRewardWeight_,
+            address trustedCreditor
+        )
+    {
+        initiatorRewardWeight_ = auctionInformation[account_].initiatorRewardWeight;
+        penaltyWeight_ = auctionInformation[account_].penaltyWeight;
+        closingRewardWeight_ = auctionInformation[account_].closingRewardWeight;
+        trustedCreditor = auctionInformation[account_].trustedCreditor;
+    }
+
     function getLocked() public view returns (uint256) {
         return locked;
     }

--- a/test/utils/Extensions.sol
+++ b/test/utils/Extensions.sol
@@ -396,6 +396,10 @@ contract LiquidatorExtension_NEW is Liquidator_NEW {
         return initiatorRewardWeight;
     }
 
+    function getClosingRewardWeight() public view returns (uint8) {
+        return closingRewardWeight;
+    }
+
     function getAssetDistribution(RiskModule.AssetValueAndRiskVariables[] memory riskValues_)
         public
         view

--- a/test/utils/mocks/LendingPoolMalicious.sol
+++ b/test/utils/mocks/LendingPoolMalicious.sol
@@ -16,5 +16,5 @@ contract LendingPoolMalicious {
         uint256 initiatorRewardWeight,
         uint256 penaltyWeight,
         uint256 closingRewardWeight
-    ) external returns (uint80 maxInitiatorFee_) { }
+    ) external returns (uint256 liquidationInitiatorReward, uint256 closingReward, uint256 liquidationPenalty) { }
 }

--- a/test/utils/mocks/LendingPoolMalicious.sol
+++ b/test/utils/mocks/LendingPoolMalicious.sol
@@ -11,5 +11,10 @@ contract LendingPoolMalicious {
 
     uint80 public maxInitiatorFee;
 
-    function startLiquidation(address account, uint256 liquidationIncentives) external { }
+    function startLiquidation(
+        address account,
+        uint256 initiatorRewardWeight,
+        uint256 penaltyWeight,
+        uint256 closingRewardWeight
+    ) external returns (uint80 maxInitiatorFee_) { }
 }

--- a/test/utils/mocks/LendingPoolMalicious.sol
+++ b/test/utils/mocks/LendingPoolMalicious.sol
@@ -11,5 +11,5 @@ contract LendingPoolMalicious {
 
     uint80 public maxInitiatorFee;
 
-    function startLiquidation(address account, uint256 debt, uint256 liquidationIncentives) external { }
+    function startLiquidation(address account, uint256 liquidationIncentives) external { }
 }

--- a/test/utils/mocks/LendingPoolMalicious.sol
+++ b/test/utils/mocks/LendingPoolMalicious.sol
@@ -9,5 +9,7 @@ import { RiskModule } from "lib/accounts-v2/src/RiskModule.sol";
 contract LendingPoolMalicious {
     constructor() { }
 
-    function startLiquidation(address account, uint256 debt) external { }
+    uint80 public maxInitiatorFee;
+
+    function startLiquidation(address account, uint256 debt, uint256 liquidationIncentives) external { }
 }


### PR DESCRIPTION
This PR accomplishes the following:

-Extra debt will be issued towards an Account on start of liquidation.
-A closing reward is introduced in order to incentivize to end an auction.
-The extra debt is equal to the liquidation incentives (initiator reward + closing reward + penalty).
-Those liquidation incentives should be taken into account when recovering an Account to a healthy state.
-All info related to an auction should be stored in the `AuctionInformation` struct.