### PR TITLE
✨ Price the liquidation auction on used margin

### DIFF
--- a/src/liquidators/LiquidatorL1.sol
+++ b/src/liquidators/LiquidatorL1.sol
@@ -415,11 +415,11 @@ contract LiquidatorL1 is Owned, ReentrancyGuard, ILiquidator {
      * calculated based on the relative value of the assets when the auction was initiated.
      * @return price The price for which the bid can be purchased, denominated in the Numeraire.
      * @dev We use a Dutch auction: price of the assets constantly decreases.
-     * @dev Price P(t) decreases exponentially over time: P(t) = Debt * S * [(SPM - MPM) * base^t + MPM]:
-     * Debt: The total debt of the Account at the moment the auction was initiated.
+     * @dev Price P(t) decreases exponentially over time: P(t) = UM * S * [(SPM - MPM) * base^t + MPM]:
+     * UM: The used margin (open debt + minimumMargin) of the Account at the moment the auction was initiated.
      * S: The share of the assets being bought in the bid.
-     * SPM: The startPriceMultiplier defines the initial price: P(0) = Debt * S * SPM (4 decimals precision).
-     * MPM: The minPriceMultiplier defines the asymptotic end price for P(∞) = Debt * MPM (4 decimals precision).
+     * SPM: The startPriceMultiplier defines the initial price: P(0) = UM * S * SPM (4 decimals precision).
+     * MPM: The minPriceMultiplier defines the asymptotic end price for P(∞) = UM * MPM (4 decimals precision).
      * base: defines how fast the exponential curve decreases (18 decimals precision).
      * t: time passed since start auction (in seconds, 18 decimals precision).
      * @dev LogExpMath was made in solidity 0.7, where operations were unchecked.
@@ -441,16 +441,16 @@ contract LiquidatorL1 is Owned, ReentrancyGuard, ILiquidator {
             // Cache minPriceMultiplier.
             uint256 minPriceMultiplier_ = auctionInformation_.minPriceMultiplier;
 
-            // Calculate askPrice as: P = Debt * S * [(SPM - MPM) * base^t + MPM]
+            // Calculate askPrice as: P = UM * S * [(SPM - MPM) * base^t + MPM]
             // P: price, denominated in the Numeraire.
-            // Debt: The initial debt of the Account, denominated in the Numeraire.
+            // UM: The used margin at auction start (initial debt + minimumMargin), denominated in the Numeraire.
             // S: The share of assets being bought, 4 decimals precision
             // SPM and MPM: multipliers to scale the price curve, 4 decimals precision.
             // base^t: the exponential decay over time of the price (strictly smaller than 1), has 18 decimals precision.
             // Since the result must be denominated in the Numeraire, we need to divide by 1e26 (1e18 + 1e4 + 1e4).
-            // No overflow possible: uint128 * uint32 * uint18 * uint18.
+            // No overflow possible: (uint128 + uint96) * uint32 * uint18 * uint18.
             price =
-                (auctionInformation_.startDebt
+                ((uint256(auctionInformation_.startDebt) + auctionInformation_.minimumMargin)
                         * totalShare
                         * (LogExpMath.pow(auctionInformation_.base, timePassed)
                             * (auctionInformation_.startPriceMultiplier - minPriceMultiplier_)

--- a/src/liquidators/LiquidatorL2.sol
+++ b/src/liquidators/LiquidatorL2.sol
@@ -477,11 +477,11 @@ contract LiquidatorL2 is Owned, ReentrancyGuard, ILiquidator {
      * calculated based on the relative value of the assets when the auction was initiated.
      * @return price The price for which the bid can be purchased, denominated in the Numeraire.
      * @dev We use a Dutch auction: price of the assets constantly decreases.
-     * @dev Price P(t) decreases exponentially over time: P(t) = Debt * S * [(SPM - MPM) * base^t + MPM]:
-     * Debt: The total debt of the Account at the moment the auction was initiated.
+     * @dev Price P(t) decreases exponentially over time: P(t) = UM * S * [(SPM - MPM) * base^t + MPM]:
+     * UM: The used margin (open debt + minimumMargin) of the Account at the moment the auction was initiated.
      * S: The share of the assets being bought in the bid.
-     * SPM: The startPriceMultiplier defines the initial price: P(0) = Debt * S * SPM (4 decimals precision).
-     * MPM: The minPriceMultiplier defines the asymptotic end price for P(∞) = Debt * MPM (4 decimals precision).
+     * SPM: The startPriceMultiplier defines the initial price: P(0) = UM * S * SPM (4 decimals precision).
+     * MPM: The minPriceMultiplier defines the asymptotic end price for P(∞) = UM * MPM (4 decimals precision).
      * base: defines how fast the exponential curve decreases (18 decimals precision).
      * t: time passed since start auction (in seconds, 18 decimals precision).
      * @dev LogExpMath was made in solidity 0.7, where operations were unchecked.
@@ -503,16 +503,16 @@ contract LiquidatorL2 is Owned, ReentrancyGuard, ILiquidator {
             // Cache minPriceMultiplier.
             uint256 minPriceMultiplier_ = auctionInformation_.minPriceMultiplier;
 
-            // Calculate askPrice as: P = Debt * S * [(SPM - MPM) * base^t + MPM]
+            // Calculate askPrice as: P = UM * S * [(SPM - MPM) * base^t + MPM]
             // P: price, denominated in the Numeraire.
-            // Debt: The initial debt of the Account, denominated in the Numeraire.
+            // UM: The used margin at auction start (initial debt + minimumMargin), denominated in the Numeraire.
             // S: The share of assets being bought, 4 decimals precision
             // SPM and MPM: multipliers to scale the price curve, 4 decimals precision.
             // base^t: the exponential decay over time of the price (strictly smaller than 1), has 18 decimals precision.
             // Since the result must be denominated in the Numeraire, we need to divide by 1e26 (1e18 + 1e4 + 1e4).
-            // No overflow possible: uint128 * uint32 * uint18 * uint18.
+            // No overflow possible: (uint128 + uint96) * uint32 * uint18 * uint18.
             price =
-                (auctionInformation_.startDebt
+                ((uint256(auctionInformation_.startDebt) + auctionInformation_.minimumMargin)
                         * totalShare
                         * (LogExpMath.pow(auctionInformation_.base, timePassed)
                             * (auctionInformation_.startPriceMultiplier - minPriceMultiplier_)

--- a/test/fuzz/liquidators/LiquidatorL1/CalculateBidPrice.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL1/CalculateBidPrice.fuzz.t.sol
@@ -63,6 +63,7 @@ contract CalculateBidPrice_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
         uint16 startPriceMultiplier,
         uint8 minPriceMultiplier,
         uint32 timePassed,
+        uint96 minimumMargin,
         uint112 amountLoaned,
         uint256 askedShare
     ) public {
@@ -76,10 +77,9 @@ contract CalculateBidPrice_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
         vm.prank(users.owner);
         liquidator_.setAuctionCurveParameters(halfLifeTime, cutoffTime, startPriceMultiplier, minPriceMultiplier);
 
-        // And: The account auction is initiated.
-        vm.assume(amountLoaned > 1);
-        vm.assume(amountLoaned <= (type(uint112).max / 300) * 100);
-        initiateLiquidation(amountLoaned);
+        // And: The account auction is initiated, with a minimumMargin that is priced into the auction.
+        amountLoaned = uint112(bound(amountLoaned, 2, (uint256(type(uint112).max) / 300) * 100 - minimumMargin));
+        initiateLiquidation(minimumMargin, amountLoaned);
 
         (uint128 startDebt,, uint32 startTime,) = liquidator_.getAuctionInformationPartOne(address(account));
 
@@ -90,9 +90,9 @@ contract CalculateBidPrice_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
         // When: calculateBidPrice is called.
         uint256 price = liquidator_.calculateBidPrice(address(account), askedShare);
 
-        // Then: The price equals the price-curve formula.
+        // Then: The price equals the price-curve formula, with the minimumMargin included in the debt term.
         uint256 expectedPrice =
-            (uint256(startDebt)
+            ((uint256(startDebt) + minimumMargin)
                     * askedShare
                     * (LogExpMath.pow(liquidator_.getBase(), uint256(timePassed) * 1e18)
                         * (liquidator_.getStartPriceMultiplier() - liquidator_.getMinPriceMultiplier())

--- a/test/fuzz/liquidators/LiquidatorL2/CalculateBidPrice.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL2/CalculateBidPrice.fuzz.t.sol
@@ -63,6 +63,7 @@ contract CalculateBidPrice_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
         uint16 startPriceMultiplier,
         uint8 minPriceMultiplier,
         uint32 timePassed,
+        uint96 minimumMargin,
         uint112 amountLoaned,
         uint256 askedShare
     ) public {
@@ -76,10 +77,9 @@ contract CalculateBidPrice_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
         vm.prank(users.owner);
         liquidator.setAuctionCurveParameters(halfLifeTime, cutoffTime, startPriceMultiplier, minPriceMultiplier);
 
-        // And: The account auction is initiated.
-        vm.assume(amountLoaned > 1);
-        vm.assume(amountLoaned <= (type(uint112).max / 300) * 100);
-        initiateLiquidation(amountLoaned);
+        // And: The account auction is initiated, with a minimumMargin that is priced into the auction.
+        amountLoaned = uint112(bound(amountLoaned, 2, (uint256(type(uint112).max) / 300) * 100 - minimumMargin));
+        initiateLiquidation(minimumMargin, amountLoaned);
 
         (uint128 startDebt,, uint32 startTime,) = liquidator.getAuctionInformationPartOne(address(account));
 
@@ -90,9 +90,9 @@ contract CalculateBidPrice_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
         // When: calculateBidPrice is called.
         uint256 price = liquidator.calculateBidPrice(address(account), askedShare);
 
-        // Then: The price equals the price-curve formula.
+        // Then: The price equals the price-curve formula, with the minimumMargin included in the debt term.
         uint256 expectedPrice =
-            (uint256(startDebt)
+            ((uint256(startDebt) + minimumMargin)
                     * askedShare
                     * (LogExpMath.pow(liquidator.getBase(), uint256(timePassed) * 1e18)
                         * (liquidator.getStartPriceMultiplier() - liquidator.getMinPriceMultiplier())


### PR DESCRIPTION
## Summary
Anchors the Dutch-auction start price to the account's used margin
(`startDebt + minimumMargin`) rather than `startDebt` alone, in `LiquidatorL1`
and `LiquidatorL2`. The opening price now scales with the margin the account
was required to hold. `startDebt` is unchanged for settlement and reward
accounting.

## Changes
- `_calculateBidPrice` in `LiquidatorL1.sol` and `LiquidatorL2.sol` use
  `startDebt + minimumMargin` as the price basis.
- NatSpec / inline comments describe the term as used margin (UM).
- `CalculateBidPrice` fuzz tests (L1 + L2) fuzz a non-zero `minimumMargin`
  and assert the new formula.

## Tests
`forge fmt` + `forge lint` clean; liquidator fuzz suite passes (129 tests).
