### PR TITLE
🚨 suppress intentional forge 1.8 lint findings

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -35,7 +35,14 @@ tab_width = 4
 
 [lint]
 exclude_lints = [
+    "asm-keccak256",
+    "calls-loop",
+    "missing-events-access-control",
+    "missing-zero-check",
+    "reentrancy-events",
+    "uninitialized-local",
     "unsafe-cheatcode",
+    "unused-return",
     "unwrapped-modifier-logic",
 ]
 

--- a/src/LendingPool.sol
+++ b/src/LendingPool.sol
@@ -226,6 +226,7 @@ contract LendingPool is LendingPoolGuardian, Creditor, DebtToken, ILendingPool {
         interestWeightTranches.push(interestWeight_);
         interestWeight[tranche] = interestWeight_;
 
+        // forge-lint: disable-next-item(unsafe-typecast)
         uint8 trancheIndex = uint8(tranches.length);
         tranches.push(tranche);
         isTranche[tranche] = true;
@@ -322,6 +323,7 @@ contract LendingPool is LendingPoolGuardian, Creditor, DebtToken, ILendingPool {
      * 4 decimal precision (10 = 0.1%).
      */
     function setOriginationFee(uint8 originationFee_) external onlyOwner {
+        // forge-lint: disable-next-item(missing-events-arithmetic)
         originationFee = originationFee_;
     }
 
@@ -343,6 +345,7 @@ contract LendingPool is LendingPoolGuardian, Creditor, DebtToken, ILendingPool {
     {
         // Need to transfer before minting or ERC777s could reenter.
         // Address(this) is trusted -> no risk on reentrancy attack after transfer.
+        // forge-lint: disable-next-item(arbitrary-send-erc20,solmate-safe-transfer-lib)
         asset.safeTransferFrom(from, address(this), assets);
 
         unchecked {
@@ -367,6 +370,7 @@ contract LendingPool is LendingPoolGuardian, Creditor, DebtToken, ILendingPool {
 
         // Need to transfer before donating or ERC777s could reenter.
         // Address(this) is trusted -> no risk on reentrancy attack after transfer.
+        // forge-lint: disable-next-item(solmate-safe-transfer-lib)
         asset.safeTransferFrom(msg.sender, address(this), assets);
 
         unchecked {
@@ -390,6 +394,7 @@ contract LendingPool is LendingPoolGuardian, Creditor, DebtToken, ILendingPool {
             totalRealisedLiquidity = SafeCastLib.safeCastTo128(totalRealisedLiquidity - assets);
         }
 
+        // forge-lint: disable-next-item(solmate-safe-transfer-lib)
         asset.safeTransfer(receiver, assets);
     }
 
@@ -455,10 +460,12 @@ contract LendingPool is LendingPoolGuardian, Creditor, DebtToken, ILendingPool {
         // UpdateOpenPosition checks that the Account indeed has opened a margin account for this Lending Pool and
         // checks that it is still healthy after the debt is increased with amountWithFee.
         // Reverts in Account if one of the checks fails.
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         uint256 accountVersion = IAccount(account).increaseOpenPosition(maxWithdraw(account));
         if (!isValidVersion[accountVersion]) revert LendingPoolErrors.InvalidVersion();
 
         // Transfer fails if there is insufficient liquidity in the pool.
+        // forge-lint: disable-next-item(solmate-safe-transfer-lib)
         asset.safeTransfer(to, amount);
 
         unchecked {
@@ -480,6 +487,7 @@ contract LendingPool is LendingPoolGuardian, Creditor, DebtToken, ILendingPool {
 
         // Need to transfer before burning debt or ERC777s could reenter.
         // Address(this) is trusted -> no risk on reentrancy attack after transfer.
+        // forge-lint: disable-next-item(solmate-safe-transfer-lib)
         asset.safeTransferFrom(msg.sender, address(this), amount);
 
         _withdraw(amount, address(this), account);
@@ -506,6 +514,7 @@ contract LendingPool is LendingPoolGuardian, Creditor, DebtToken, ILendingPool {
     {
         // Need to transfer before burning debt or ERC777s could reenter.
         // Address(this) is trusted -> no risk on reentrancy attack after transfer.
+        // forge-lint: disable-next-item(arbitrary-send-erc20,solmate-safe-transfer-lib)
         asset.safeTransferFrom(bidder, address(this), amount);
 
         uint256 accountDebt = maxWithdraw(account);
@@ -573,6 +582,7 @@ contract LendingPool is LendingPoolGuardian, Creditor, DebtToken, ILendingPool {
         // The Collateral Value of all assets in the Account must be bigger than the total liabilities against the Account (including the debt taken during this function).
         // flashActionByCreditor also checks that the Account indeed has opened a margin account for this Lending Pool.
         {
+            // forge-lint: disable-next-item(reentrancy-no-eth)
             uint256 accountVersion = IAccount(account).flashActionByCreditor(callbackData, actionTarget, actionData);
             if (!isValidVersion[accountVersion]) revert LendingPoolErrors.InvalidVersion();
         }
@@ -604,6 +614,7 @@ contract LendingPool is LendingPoolGuardian, Creditor, DebtToken, ILendingPool {
 
         // Send Borrowed funds to the actionTarget.
         // Transfer fails if there is insufficient liquidity in the pool.
+        // forge-lint: disable-next-item(solmate-safe-transfer-lib)
         asset.safeTransfer(actionTarget, amountBorrowed);
 
         unchecked {
@@ -622,7 +633,7 @@ contract LendingPool is LendingPoolGuardian, Creditor, DebtToken, ILendingPool {
     function totalAssets() public view override returns (uint256 totalDebt) {
         // Avoid a second calculation of unrealised debt (expensive)
         // if interests are already synced this block.
-        // forge-lint: disable-next-line(block-timestamp)
+        // forge-lint: disable-next-item(block-timestamp,unsafe-typecast)
         if (lastSyncedTimestamp != uint32(block.timestamp)) {
             totalDebt = realisedDebt + calcUnrealisedDebt();
         } else {
@@ -637,7 +648,7 @@ contract LendingPool is LendingPoolGuardian, Creditor, DebtToken, ILendingPool {
     function totalLiquidity() external view returns (uint256 totalLiquidity_) {
         // Avoid a second calculation of unrealised debt (expensive)
         // if interests are already synced this block.
-        // forge-lint: disable-next-line(block-timestamp)
+        // forge-lint: disable-next-item(block-timestamp,unsafe-typecast)
         if (lastSyncedTimestamp != uint32(block.timestamp)) {
             // The total liquidity equals the sum of the realised liquidity, and the pending interests.
             unchecked {
@@ -672,7 +683,7 @@ contract LendingPool is LendingPoolGuardian, Creditor, DebtToken, ILendingPool {
     function liquidityOf(address owner_) external view returns (uint256 assets) {
         // Avoid a second calculation of unrealised debt (expensive).
         // if interests are already synced this block.
-        // forge-lint: disable-next-line(block-timestamp)
+        // forge-lint: disable-next-item(block-timestamp,unsafe-typecast)
         if (lastSyncedTimestamp != uint32(block.timestamp)) {
             // The total liquidity of a tranche equals the sum of the realised liquidity
             // of the tranche, and its pending interests.
@@ -722,9 +733,10 @@ contract LendingPool is LendingPoolGuardian, Creditor, DebtToken, ILendingPool {
      */
     function _syncInterests() internal {
         // Only Sync interests once per block.
-        // forge-lint: disable-next-line(block-timestamp)
+        // forge-lint: disable-next-item(block-timestamp,unsafe-typecast)
         if (lastSyncedTimestamp != uint32(block.timestamp)) {
             uint256 unrealisedDebt = calcUnrealisedDebt();
+            // forge-lint: disable-next-item(unsafe-typecast)
             lastSyncedTimestamp = uint32(block.timestamp);
 
             // Sync interests for borrowers.
@@ -925,6 +937,7 @@ contract LendingPool is LendingPoolGuardian, Creditor, DebtToken, ILendingPool {
         // If this is the sole ongoing auction, prevent any deposits and withdrawals in the most jr tranche
         if (auctionsInProgress == 0 && tranches.length > 0) {
             unchecked {
+                // forge-lint: disable-next-item(reentrancy-no-eth)
                 ITranche(tranches[tranches.length - 1]).setAuctionInProgress(true);
             }
         }
@@ -934,7 +947,7 @@ contract LendingPool is LendingPoolGuardian, Creditor, DebtToken, ILendingPool {
         }
 
         // Emit event
-        // forge-lint: disable-next-line(unsafe-typecast)
+        // forge-lint: disable-next-item(unsafe-typecast)
         emit AuctionStarted(msg.sender, address(this), uint128(startDebt));
     }
 
@@ -1086,6 +1099,7 @@ contract LendingPool is LendingPoolGuardian, Creditor, DebtToken, ILendingPool {
         // Hook to the most junior Tranche.
         if (auctionsInProgress == 0 && tranches.length > 0) {
             unchecked {
+                // forge-lint: disable-next-item(reentrancy-no-eth)
                 ITranche(tranches[tranches.length - 1]).setAuctionInProgress(false);
             }
         }
@@ -1114,6 +1128,7 @@ contract LendingPool is LendingPoolGuardian, Creditor, DebtToken, ILendingPool {
             if (badDebt < maxBurnable) {
                 // Deduct badDebt from the balance of the most junior Tranche.
                 unchecked {
+                    // forge-lint: disable-next-item(unsafe-typecast)
                     realisedLiquidityOf[tranche] -= badDebt;
                 }
                 break;
@@ -1127,8 +1142,10 @@ contract LendingPool is LendingPoolGuardian, Creditor, DebtToken, ILendingPool {
                 unchecked {
                     badDebt -= maxBurnable;
                 }
+                // forge-lint: disable-next-item(reentrancy-no-eth)
                 ITranche(tranche).lock();
                 // Hook to the new most junior Tranche to inform that auctions are ongoing.
+                // forge-lint: disable-next-item(reentrancy-no-eth)
                 if (i != 0) ITranche(tranches[i - 1]).setAuctionInProgress(true);
             }
         }

--- a/src/Tranche.sol
+++ b/src/Tranche.sol
@@ -92,6 +92,7 @@ contract Tranche is ITranche, ERC4626, Owned {
      * @param prefixSymbol_ The prefix of the contract symbol (eg. SR  -> MZ -> JR).
      * @dev The name and symbol of the tranche are automatically generated, based on the name and symbol of the underlying token.
      */
+    // forge-lint: disable-next-item(encode-packed-collision)
     constructor(address owner_, address lendingPool_, uint256 vas, string memory prefix_, string memory prefixSymbol_)
         ERC4626(
             ERC4626(address(lendingPool_)).asset(),
@@ -165,6 +166,7 @@ contract Tranche is ITranche, ERC4626, Owned {
         if ((shares = previewDepositAndSync(assets)) == 0) revert TrancheErrors.ZeroShares();
 
         // Need to transfer (via lendingPool.depositInLendingPool()) before minting or ERC777s could reenter.
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         LENDING_POOL.depositInLendingPool(assets, msg.sender);
 
         _mint(receiver, shares);
@@ -192,6 +194,7 @@ contract Tranche is ITranche, ERC4626, Owned {
         assets = previewMintAndSync(shares);
 
         // Need to transfer (via lendingPool.depositInLendingPool()) before minting or ERC777s could reenter.
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         LENDING_POOL.depositInLendingPool(assets, msg.sender);
 
         _mint(receiver, shares);
@@ -280,6 +283,7 @@ contract Tranche is ITranche, ERC4626, Owned {
      * @dev Modification of totalAssets() where interests are realised (state modification).
      */
     function totalAssetsAndSync() public returns (uint256 assets) {
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         assets = LENDING_POOL.liquidityOfAndSync(address(this));
     }
 

--- a/src/guardians/LendingPoolGuardian.sol
+++ b/src/guardians/LendingPoolGuardian.sol
@@ -109,6 +109,7 @@ abstract contract LendingPoolGuardian is BaseGuardian {
      * - Liquidate positions.
      */
     function pause() external override onlyGuardian afterCoolDownOf(1441 minutes) {
+        // forge-lint: disable-next-item(unsafe-typecast)
         pauseTimestamp = uint96(block.timestamp);
 
         emit PauseFlagsUpdated(

--- a/src/libraries/BalancerErrors.sol
+++ b/src/libraries/BalancerErrors.sol
@@ -40,6 +40,7 @@ function _revert(uint256 errorCode) pure {
     // The dynamic string creation algorithm that follows could be implemented in Solidity, but assembly allows for a
     // much denser implementation, again saving bytecode size. Given this function unconditionally reverts, this is a
     // safe place to rely on it without worrying about how its usage might affect e.g. memory contents.
+    // forge-lint: disable-next-item(unsafe-typecast)
     assembly {
         // First, we need to compute the ASCII representation of the error code. We assume that it is in the 0-999
         // range, so we only need to convert three digits. To convert the digits to ASCII, we add 0x30, the value for

--- a/src/libraries/LogExpMath.sol
+++ b/src/libraries/LogExpMath.sol
@@ -139,6 +139,7 @@ library LogExpMath {
         return uint256(exp(logx_times_y));
     }
 
+    // forge-lint: disable-next-item(unsafe-typecast)
     /**
      * @dev Natural exponentiation (e^x) with signed 18 decimal fixed point exponent.
      *

--- a/src/liquidators/LiquidatorL1.sol
+++ b/src/liquidators/LiquidatorL1.sol
@@ -174,6 +174,7 @@ contract LiquidatorL1 is Owned, ReentrancyGuard, ILiquidator {
         if (cutoffTime_ > 64_800) revert LiquidatorErrors.CutOffTooHigh(); // 18 hours.
 
         // Derive base from the halfLifeTime.
+        // forge-lint: disable-next-item(unsafe-typecast)
         uint64 base_ = uint64(1e18 * 1e18 / LogExpMath.pow(2 * 1e18, 1e18 / halfLifeTime));
 
         // Check that LogExpMath.pow(base, timePassed) does not error at cutoffTime (due to numbers smaller than minimum precision).
@@ -217,6 +218,7 @@ contract LiquidatorL1 is Owned, ReentrancyGuard, ILiquidator {
         // Store the auction price-curve parameters.
         // This ensures that changes of the price-curve parameters do not impact ongoing auctions.
         auctionInformation_.base = base;
+        // forge-lint: disable-next-item(unsafe-typecast)
         auctionInformation_.startTime = uint32(block.timestamp);
         auctionInformation_.cutoffTime = cutoffTime;
         auctionInformation_.startPriceMultiplier = startPriceMultiplier;
@@ -225,6 +227,7 @@ contract LiquidatorL1 is Owned, ReentrancyGuard, ILiquidator {
         // Check if the Account is insolvent and if it is, start the liquidation in the Account.
         // startLiquidation will revert if the Account is still solvent.
         // set by the Creditor, has passed.
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         (
             address[] memory assetAddresses,
             uint256[] memory assetIds,
@@ -271,6 +274,7 @@ contract LiquidatorL1 is Owned, ReentrancyGuard, ILiquidator {
 
         for (uint256 i; i < length; ++i) {
             // The asset shares are calculated relative to the total value of the Account.
+            // forge-lint: disable-next-item(unsafe-typecast)
             assetShares[i] = uint32(assetValues[i].assetValue.mulDivUp(ONE_4, totalValue));
         }
     }
@@ -330,6 +334,7 @@ contract LiquidatorL1 is Owned, ReentrancyGuard, ILiquidator {
 
         // Transfer the assets to the bidder, returns updated bidAmounts with the actual bought assets.
         // The actual bought assets are equal or smaller than the asked assets.
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         bidAmounts = IAccount(account)
             .auctionBid(auctionInformation_.assetAddresses, auctionInformation_.assetIds, bidAmounts, msg.sender);
 
@@ -341,11 +346,13 @@ contract LiquidatorL1 is Owned, ReentrancyGuard, ILiquidator {
         // Bidders can optionally first liquidate the assets before repaying the debt.
         // Bidders should NOT call a LendingPool.repay() or LendingPool.auctionRepay() within the callback,
         // as this will cause the bidder to pay twice!
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         if (msg.sender.code.length > 0) IBidCallback(msg.sender).bidCallback(bidAmounts, price, data);
 
         // Transfer an amount of "price" in "Numeraire" to the LendingPool to repay the Accounts debt.
         // The LendingPool will call a "transferFrom" from the bidder to the pool -> the bidder must approve the LendingPool.
         // If the amount transferred would exceed the debt, the surplus is paid out to the Account Owner and earlyTerminate is True.
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         bool earlyTerminate = ILendingPool(auctionInformation_.creditor)
             .auctionRepay(auctionInformation_.startDebt, auctionInformation_.minimumMargin, price, account, msg.sender);
 
@@ -379,6 +386,7 @@ contract LiquidatorL1 is Owned, ReentrancyGuard, ILiquidator {
     {
         AuctionInformation storage auctionInformation_ = auctionInformation[account];
         inAuction = auctionInformation_.inAuction;
+        // forge-lint: disable-next-item(boolean-cst)
         if (!inAuction) return (0, false);
         // Calculate the current auction price of the assets being bought.
         uint256 totalShare = _calculateTotalShare(auctionInformation_, askedAssetAmounts);
@@ -518,6 +526,7 @@ contract LiquidatorL1 is Owned, ReentrancyGuard, ILiquidator {
                 // Happy flow: Account is back in a healthy state.
                 // An Account is healthy if the collateral value is equal or greater than the used margin.
                 // If usedMargin is equal to minimumMargin, the open liabilities are 0 and the Account is always healthy.
+                // forge-lint: disable-next-item(reentrancy-no-eth)
                 ILendingPool(creditor).settleLiquidationHappyFlow(account, startDebt, minimumMargin, msg.sender);
             } else if (IAccount(account).getAccountValue(IAccount(account).numeraire()) == 0) {
                 // Unhappy flow: The remaining assets have no more value.
@@ -542,7 +551,9 @@ contract LiquidatorL1 is Owned, ReentrancyGuard, ILiquidator {
      * If the Account still holds assets, a manual (trusted) liquidation of these has to be done.
      */
     function _settleUnhappyFlow(address account, uint256 startDebt, uint96 minimumMargin, address creditor) internal {
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         ILendingPool(creditor).settleLiquidationUnhappyFlow(account, startDebt, minimumMargin, msg.sender);
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         IAccount(account).auctionBoughtIn(creditorToAccountRecipient[creditor]);
     }
 
@@ -551,6 +562,7 @@ contract LiquidatorL1 is Owned, ReentrancyGuard, ILiquidator {
      */
     function _endAuction(address account) internal {
         delete auctionInformation[account];
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         IAccount(account).endAuction();
     }
 }

--- a/src/liquidators/LiquidatorL2.sol
+++ b/src/liquidators/LiquidatorL2.sol
@@ -226,6 +226,7 @@ contract LiquidatorL2 is Owned, ReentrancyGuard, ILiquidator {
         if (cutoffTime_ > 64_800) revert LiquidatorErrors.CutOffTooHigh(); // 18 hours.
 
         // Derive base from the halfLifeTime.
+        // forge-lint: disable-next-item(unsafe-typecast)
         uint64 base_ = uint64(1e18 * 1e18 / LogExpMath.pow(2 * 1e18, 1e18 / halfLifeTime));
 
         // Check that LogExpMath.pow(base, timePassed) does not error at cutoffTime (due to numbers smaller than minimum precision).
@@ -269,6 +270,7 @@ contract LiquidatorL2 is Owned, ReentrancyGuard, ILiquidator {
         // Store the auction price-curve parameters.
         // This ensures that changes of the price-curve parameters do not impact ongoing auctions.
         auctionInformation_.base = base;
+        // forge-lint: disable-next-item(unsafe-typecast)
         auctionInformation_.startTime = uint32(block.timestamp);
         auctionInformation_.cutoffTime = cutoffTime;
         auctionInformation_.startPriceMultiplier = startPriceMultiplier;
@@ -278,6 +280,7 @@ contract LiquidatorL2 is Owned, ReentrancyGuard, ILiquidator {
         // startLiquidation will revert if the Account is still solvent.
         // startLiquidation will revert if the sequencer is down, or if less then the grace period,
         // set by the Creditor, has passed.
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         (
             address[] memory assetAddresses,
             uint256[] memory assetIds,
@@ -324,6 +327,7 @@ contract LiquidatorL2 is Owned, ReentrancyGuard, ILiquidator {
 
         for (uint256 i; i < length; ++i) {
             // The asset shares are calculated relative to the total value of the Account.
+            // forge-lint: disable-next-item(unsafe-typecast)
             assetShares[i] = uint32(assetValues[i].assetValue.mulDivUp(ONE_4, totalValue));
         }
     }
@@ -390,6 +394,7 @@ contract LiquidatorL2 is Owned, ReentrancyGuard, ILiquidator {
 
         // Transfer the assets to the bidder, returns updated bidAmounts with the actual bought assets.
         // The actual bought assets are equal or smaller than the asked assets.
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         bidAmounts = IAccount(account)
             .auctionBid(auctionInformation_.assetAddresses, auctionInformation_.assetIds, bidAmounts, msg.sender);
 
@@ -401,11 +406,13 @@ contract LiquidatorL2 is Owned, ReentrancyGuard, ILiquidator {
         // Bidders can optionally first liquidate the assets before repaying the debt.
         // Bidders should NOT call a LendingPool.repay() or LendingPool.auctionRepay() within the callback,
         // as this will cause the bidder to pay twice!
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         if (msg.sender.code.length > 0) IBidCallback(msg.sender).bidCallback(bidAmounts, price, data);
 
         // Transfer an amount of "price" in "Numeraire" to the LendingPool to repay the Accounts debt.
         // The LendingPool will call a "transferFrom" from the bidder to the pool -> the bidder must approve the LendingPool.
         // If the amount transferred would exceed the debt, the surplus is paid out to the Account Owner and earlyTerminate is True.
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         bool earlyTerminate = ILendingPool(auctionInformation_.creditor)
             .auctionRepay(auctionInformation_.startDebt, auctionInformation_.minimumMargin, price, account, msg.sender);
 
@@ -441,6 +448,7 @@ contract LiquidatorL2 is Owned, ReentrancyGuard, ILiquidator {
     {
         AuctionInformation storage auctionInformation_ = auctionInformation[account];
         inAuction = auctionInformation_.inAuction;
+        // forge-lint: disable-next-item(boolean-cst)
         if (!inAuction) return (0, false);
         // Calculate the current auction price of the assets being bought.
         uint256 totalShare = _calculateTotalShare(auctionInformation_, askedAssetAmounts);
@@ -587,6 +595,7 @@ contract LiquidatorL2 is Owned, ReentrancyGuard, ILiquidator {
                 // Happy flow: Account is back in a healthy state.
                 // An Account is healthy if the collateral value is equal or greater than the used margin.
                 // If usedMargin is equal to minimumMargin, the open liabilities are 0 and the Account is always healthy.
+                // forge-lint: disable-next-item(reentrancy-no-eth)
                 ILendingPool(creditor).settleLiquidationHappyFlow(account, startDebt, minimumMargin, msg.sender);
             } else if (IAccount(account).getAccountValue(IAccount(account).numeraire()) == 0) {
                 // Unhappy flow: The remaining assets have no more value.
@@ -612,7 +621,9 @@ contract LiquidatorL2 is Owned, ReentrancyGuard, ILiquidator {
      * If the Account still holds assets, a manual (trusted) liquidation of these has to be done.
      */
     function _settleUnhappyFlow(address account, uint256 startDebt, uint96 minimumMargin, address creditor) internal {
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         ILendingPool(creditor).settleLiquidationUnhappyFlow(account, startDebt, minimumMargin, msg.sender);
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         IAccount(account).auctionBoughtIn(creditorToAccountRecipient[creditor]);
     }
 
@@ -621,6 +632,7 @@ contract LiquidatorL2 is Owned, ReentrancyGuard, ILiquidator {
      */
     function _endAuction(address account) internal {
         delete auctionInformation[account];
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         IAccount(account).endAuction();
     }
 }

--- a/src/periphery/tranche-wrapper/TrancheWrapper.sol
+++ b/src/periphery/tranche-wrapper/TrancheWrapper.sol
@@ -60,9 +60,11 @@ contract TrancheWrapper is ERC4626 {
      * @return shares The amount of shares minted.
      */
     function deposit(uint256 assets, address receiver) public override returns (uint256 shares) {
+        // forge-lint: disable-next-item(solmate-safe-transfer-lib)
         asset.safeTransferFrom(msg.sender, address(this), assets);
 
         // Approval has to be given to the Lending Pool, not the Tranche.
+        // forge-lint: disable-next-item(solmate-safe-transfer-lib)
         asset.safeApprove(LENDING_POOL, assets);
 
         shares = ERC4626(TRANCHE).deposit(assets, address(this));
@@ -79,9 +81,11 @@ contract TrancheWrapper is ERC4626 {
      */
     function mint(uint256 shares, address receiver) public override returns (uint256 assets) {
         assets = ITranche(TRANCHE).previewMintAndSync(shares);
+        // forge-lint: disable-next-item(solmate-safe-transfer-lib)
         asset.safeTransferFrom(msg.sender, address(this), assets);
 
         // Approval has to be given to the Lending Pool, not the Tranche.
+        // forge-lint: disable-next-item(solmate-safe-transfer-lib)
         asset.safeApprove(LENDING_POOL, assets);
 
         ERC4626(TRANCHE).mint(shares, address(this));
@@ -107,6 +111,7 @@ contract TrancheWrapper is ERC4626 {
 
         _burn(owner, shares);
         ERC4626(TRANCHE).withdraw(assets, address(this), address(this));
+        // forge-lint: disable-next-item(solmate-safe-transfer-lib)
         asset.safeTransfer(receiver, assets);
 
         emit Withdraw(msg.sender, receiver, owner, assets, shares);
@@ -127,6 +132,7 @@ contract TrancheWrapper is ERC4626 {
 
         _burn(owner, shares);
         assets = ERC4626(TRANCHE).redeem(shares, address(this), address(this));
+        // forge-lint: disable-next-item(solmate-safe-transfer-lib)
         asset.safeTransfer(receiver, assets);
 
         emit Withdraw(msg.sender, receiver, owner, assets, shares);

--- a/test/fuzz/DebtToken/Deposit.fuzz.t.sol
+++ b/test/fuzz/DebtToken/Deposit.fuzz.t.sol
@@ -59,6 +59,7 @@ contract Deposit_DebtToken_Fuzz_Test is DebtToken_Fuzz_Test {
         debt_.setRealisedDebt(totalDebt);
 
         uint256 shares = assets * totalSupply / totalDebt;
+        // forge-lint: disable-next-item(divide-before-multiply)
         if (shares * totalDebt < assets * totalSupply) {
             //Must round up
             shares += 1;

--- a/test/fuzz/DebtToken/TransferFrom.fuzz.t.sol
+++ b/test/fuzz/DebtToken/TransferFrom.fuzz.t.sol
@@ -26,7 +26,7 @@ contract TransferFrom_DebtToken_Fuzz_Test is DebtToken_Fuzz_Test {
     function testFuzz_Revert_transferFrom(address from, address to, uint256 amount, address sender) public {
         vm.startPrank(sender);
         vm.expectRevert(DebtTokenErrors.FunctionNotImplemented.selector);
-        // forge-lint: disable-next-line(erc20-unchecked-transfer)
+        // forge-lint: disable-next-item(arbitrary-send-erc20,erc20-unchecked-transfer)
         debt_.transferFrom(from, to, amount);
         vm.stopPrank();
     }

--- a/test/fuzz/LendingPool/AuctionRepay.fuzz.t.sol
+++ b/test/fuzz/LendingPool/AuctionRepay.fuzz.t.sol
@@ -15,6 +15,7 @@ import { LendingPoolErrors } from "../../../src/libraries/Errors.sol";
 /**
  * @notice Fuzz tests for the function "repay" of contract "LendingPool".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract AuctionRepay_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/LendingPool/Borrow.fuzz.t.sol
+++ b/test/fuzz/LendingPool/Borrow.fuzz.t.sol
@@ -18,6 +18,7 @@ import { stdStorage, StdStorage } from "../../../lib/accounts-v2/lib/forge-std/s
 /**
  * @notice Fuzz tests for the function "borrow" of contract "LendingPool".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract Borrow_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     using stdStorage for StdStorage;
     using FixedPointMathLib for uint256;

--- a/test/fuzz/LendingPool/CalcUnrealisedDebt.fuzz.t.sol
+++ b/test/fuzz/LendingPool/CalcUnrealisedDebt.fuzz.t.sol
@@ -34,6 +34,7 @@ contract CalcUnrealisedDebt_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         //highest possible debt at 1000% over 5 years: 3402823669209384912995114146594816
 
         pool.setInterestRate(interestRate);
+        // forge-lint: disable-next-item(unsafe-typecast)
         pool.setLastSyncedTimestamp(uint32(block.timestamp));
         pool.setRealisedDebt(realisedDebt);
 

--- a/test/fuzz/LendingPool/CalculateInterestRate.fuzz.t.sol
+++ b/test/fuzz/LendingPool/CalculateInterestRate.fuzz.t.sol
@@ -9,6 +9,7 @@ import { LendingPool_Fuzz_Test } from "./_LendingPool.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "calculateInterestRate" of contract "InterestRateModule".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract CalculateInterestRate_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/LendingPool/CloseMarginAccount.fuzz.t.sol
+++ b/test/fuzz/LendingPool/CloseMarginAccount.fuzz.t.sol
@@ -25,6 +25,7 @@ contract CloseMarginAccount_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     //////////////////////////////////////////////////////////////*/
     function testFuzz_Revert_closeMarginAccount_OpenPositionNonZero(uint112 amountLoaned) public {
         // Given: collateralValue is smaller than maxExposure.
+        // forge-lint: disable-next-item(unsafe-typecast)
         amountLoaned = uint112(bound(amountLoaned, 0, type(uint112).max - 1));
 
         // Given: an Account has taken out debt

--- a/test/fuzz/LendingPool/FlashAction.fuzz.t.sol
+++ b/test/fuzz/LendingPool/FlashAction.fuzz.t.sol
@@ -16,6 +16,7 @@ import { LendingPoolErrors } from "../../../src/libraries/Errors.sol";
 /**
  * @notice Fuzz tests for the function "flashAction" of contract "LendingPool".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract FlashAction_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     using FixedPointMathLib for uint256;
 

--- a/test/fuzz/LendingPool/GetOpenPosition.fuzz.t.sol
+++ b/test/fuzz/LendingPool/GetOpenPosition.fuzz.t.sol
@@ -23,6 +23,7 @@ contract GetOpenPosition_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     //////////////////////////////////////////////////////////////*/
     function testFuzz_Success_getOpenPosition(uint112 amountLoaned) public {
         // Given: collateralValue is smaller than maxExposure.
+        // forge-lint: disable-next-item(unsafe-typecast)
         amountLoaned = uint112(bound(amountLoaned, 0, type(uint112).max - 1));
 
         // Given: an Account has taken out debt

--- a/test/fuzz/LendingPool/LiquidityOf.fuzz.t.sol
+++ b/test/fuzz/LendingPool/LiquidityOf.fuzz.t.sol
@@ -9,6 +9,7 @@ import { LendingPool_Fuzz_Test } from "./_LendingPool.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "liquidityOf" of contract "LendingPool".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract LiquidityOf_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -100,6 +101,7 @@ contract LiquidityOf_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         vm.assume(interestRate <= 1e3 * 10 ** 18); // 1000%
         vm.assume(interestRate > 0);
         vm.assume(initialLiquidityTranche >= realisedDebt);
+        // forge-lint: disable-next-item(type-based-tautology)
         vm.assume(initialLiquidityTranche >= 0);
 
         vm.prank(address(srTranche));

--- a/test/fuzz/LendingPool/Repay.fuzz.t.sol
+++ b/test/fuzz/LendingPool/Repay.fuzz.t.sol
@@ -14,6 +14,7 @@ import { LendingPool } from "../../../src/LendingPool.sol";
 /**
  * @notice Fuzz tests for the function "repay" of contract "LendingPool".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract Repay_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/LendingPool/SetLiquidationParameters.fuzz.t.sol
+++ b/test/fuzz/LendingPool/SetLiquidationParameters.fuzz.t.sol
@@ -10,6 +10,7 @@ import { LendingPoolErrors } from "../../../src/libraries/Errors.sol";
 /**
  * @notice Fuzz tests for the function "setLiquidationParameters" of contract "LendingPool".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract SetLiquidationParameters_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/LendingPool/SettleLiquidationHappy.fuzz.t.sol
+++ b/test/fuzz/LendingPool/SettleLiquidationHappy.fuzz.t.sol
@@ -46,6 +46,7 @@ contract SettleLiquidationHappy_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         address auctionTerminator,
         uint128 surplus
     ) public {
+        // forge-lint: disable-next-item(unsafe-typecast)
         surplus = uint128(bound(surplus, 1, type(uint128).max));
         vm.assume(startDebt > 0);
         (uint256 initiationReward, uint256 auctionTerminationReward, uint256 liquidationPenalty) =

--- a/test/fuzz/LendingPool/SettleLiquidationUnhappy.fuzz.t.sol
+++ b/test/fuzz/LendingPool/SettleLiquidationUnhappy.fuzz.t.sol
@@ -13,6 +13,7 @@ import { stdStorage, StdStorage } from "../../../lib/accounts-v2/lib/forge-std/s
 /**
  * @notice Fuzz tests for the function "settleLiquidationUnhappyFlow" of contract "LendingPool".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract SettleLiquidationUnhappy_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/LendingPool/SyncInterestsToLiquidityProviders.fuzz.t.sol
+++ b/test/fuzz/LendingPool/SyncInterestsToLiquidityProviders.fuzz.t.sol
@@ -9,6 +9,7 @@ import { LendingPool_Fuzz_Test } from "./_LendingPool.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "syncInterestsToLendingPool" of contract "LendingPool".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract SyncInterestsToLendingPool_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/LendingPool/SyncLiquidationFee.fuzz.t.sol
+++ b/test/fuzz/LendingPool/SyncLiquidationFee.fuzz.t.sol
@@ -9,6 +9,7 @@ import { LendingPool_Fuzz_Test } from "./_LendingPool.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "syncLiquidationFee" of contract "LendingPool".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract SyncLiquidationFee_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/LendingPool/TotalAssets.fuzz.t.sol
+++ b/test/fuzz/LendingPool/TotalAssets.fuzz.t.sol
@@ -23,6 +23,7 @@ contract TotalAssets_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     //////////////////////////////////////////////////////////////*/
     function testFuzz_Success_totalAssets(uint112 realisedDebt, uint80 interestRate, uint24 deltaTimestamp) public {
         // Given: collateralValue is smaller than maxExposure.
+        // forge-lint: disable-next-item(unsafe-typecast)
         realisedDebt = uint112(bound(realisedDebt, 1, type(uint112).max - 1));
         vm.assume(interestRate <= 1e3 * 1e18); // 1000%.
         vm.assume(interestRate > 0);

--- a/test/fuzz/LendingPool/TotalLiquidity.fuzz.t.sol
+++ b/test/fuzz/LendingPool/TotalLiquidity.fuzz.t.sol
@@ -28,6 +28,7 @@ contract TotalLiquidity_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         uint120 initialLiquidity
     ) public {
         // Given: collateralValue is smaller than maxExposure.
+        // forge-lint: disable-next-item(unsafe-typecast)
         realisedDebt = uint112(bound(realisedDebt, 1, type(uint112).max - 1));
         vm.assume(deltaTimestamp <= 5 * 365 * 24 * 60 * 60); // 5 year
         vm.assume(interestRate <= 1e3 * 10 ** 18); // 1000%

--- a/test/fuzz/LendingPool/UpdateInterestRate.fuzz.t.sol
+++ b/test/fuzz/LendingPool/UpdateInterestRate.fuzz.t.sol
@@ -11,6 +11,7 @@ import { LendingPool } from "../../../src/LendingPool.sol";
 /**
  * @notice Fuzz tests for the function "updateInterestRate" of contract "LendingPool".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract UpdateInterestRate_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -86,6 +87,7 @@ contract UpdateInterestRate_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         uint256 expectedInterestRate;
         uint256 utilisation = (ONE_4 * realisedDebt_) / totalRealisedLiquidity_;
         if (utilisation <= utilisationThreshold_) {
+            // forge-lint: disable-next-item(divide-before-multiply)
             expectedInterestRate = uint256(baseRate_) + uint256(lowSlope_) * utilisation / ONE_4;
         } else {
             uint256 lowSlopeInterest = uint256(utilisationThreshold_) * lowSlope_;

--- a/test/fuzz/Tranche/PreviewMint.fuzz.t.sol
+++ b/test/fuzz/Tranche/PreviewMint.fuzz.t.sol
@@ -46,6 +46,7 @@ contract PreviewMint_Tranche_Fuzz_Test is Tranche_Fuzz_Test {
         // Then: correct number of shares is returned.
         uint256 expectedAssets = shares * (uint256(totalAssets) + vas) / (totalSupply + vas);
         // Rounds up.
+        // forge-lint: disable-next-item(divide-before-multiply)
         if ((totalSupply + vas) * expectedAssets < shares * (uint256(totalAssets) + vas)) expectedAssets++;
         assertEq(actualAssets, expectedAssets);
         assertEq(actualAssets, actualAssets_);

--- a/test/fuzz/Tranche/PreviewWithdraw.fuzz.t.sol
+++ b/test/fuzz/Tranche/PreviewWithdraw.fuzz.t.sol
@@ -47,6 +47,7 @@ contract PreviewWithdraw_Tranche_Fuzz_Test is Tranche_Fuzz_Test {
         // Then: correct number of shares is returned.
         uint256 expectedShares = assets * (totalSupply + vas) / (uint256(totalAssets) + vas);
         // Rounds up.
+        // forge-lint: disable-next-item(divide-before-multiply)
         if ((uint256(totalAssets) + vas) * expectedShares < assets * (totalSupply + vas)) expectedShares++;
         assertEq(actualShares, expectedShares);
         assertEq(actualShares, actualShares_);

--- a/test/fuzz/Tranche/_Tranche.fuzz.t.sol
+++ b/test/fuzz/Tranche/_Tranche.fuzz.t.sol
@@ -12,6 +12,7 @@ import { TrancheExtension } from "../../utils/extensions/TrancheExtension.sol";
 /**
  * @notice Common logic needed by all "Tranche" fuzz tests.
  */
+// forge-lint: disable-next-item(reentrancy-no-eth)
 abstract contract Tranche_Fuzz_Test is Fuzz_Lending_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/TrancheWrapper/Deposit.fuzz.t.sol
+++ b/test/fuzz/TrancheWrapper/Deposit.fuzz.t.sol
@@ -10,6 +10,7 @@ import { TrancheErrors } from "../../../src/libraries/Errors.sol";
 /**
  * @notice Fuzz tests for the function "deposit" of contract "Tranche Wrapper".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract Deposit_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/TrancheWrapper/Mint.fuzz.t.sol
+++ b/test/fuzz/TrancheWrapper/Mint.fuzz.t.sol
@@ -11,6 +11,7 @@ import { TrancheWrapper_Fuzz_Test } from "./_TrancheWrapper.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "totalAssets" of contract "Tranche".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract Mint_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/TrancheWrapper/PreviewMint.fuzz.t.sol
+++ b/test/fuzz/TrancheWrapper/PreviewMint.fuzz.t.sol
@@ -45,6 +45,7 @@ contract PreviewMint_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
         // Then: correct number of shares is returned.
         uint256 expectedAssets = shares * (uint256(totalAssets) + vas) / (totalSupply + vas);
         // Rounds up.
+        // forge-lint: disable-next-item(divide-before-multiply)
         if ((totalSupply + vas) * expectedAssets < shares * (uint256(totalAssets) + vas)) expectedAssets++;
         assertEq(actualAssets, expectedAssets);
         assertEq(actualAssets, actualAssets_);

--- a/test/fuzz/TrancheWrapper/PreviewWithdraw.fuzz.t.sol
+++ b/test/fuzz/TrancheWrapper/PreviewWithdraw.fuzz.t.sol
@@ -48,6 +48,7 @@ contract PreviewWithdraw_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
         // Then: correct number of shares is returned.
         uint256 expectedShares = assets * (totalSupply + vas) / (uint256(totalAssets) + vas);
         // Rounds up.
+        // forge-lint: disable-next-item(divide-before-multiply)
         if ((uint256(totalAssets) + vas) * expectedShares < assets * (totalSupply + vas)) expectedShares++;
         assertEq(actualShares, expectedShares);
         assertEq(actualShares, actualShares_);

--- a/test/fuzz/TrancheWrapper/Redeem.fuzz.t.sol
+++ b/test/fuzz/TrancheWrapper/Redeem.fuzz.t.sol
@@ -9,6 +9,7 @@ import { TrancheErrors } from "../../../src/libraries/Errors.sol";
 /**
  * @notice Fuzz tests for the function "withdraw" of contract "Tranche Wrapper".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract Redeem_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/TrancheWrapper/TotalAssets.fuzz.t.sol
+++ b/test/fuzz/TrancheWrapper/TotalAssets.fuzz.t.sol
@@ -11,6 +11,7 @@ import { stdStorage, StdStorage } from "../../../lib/accounts-v2/lib/forge-std/s
 /**
  * @notice Fuzz tests for the function "totalAssets" of contract "Tranche".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract TotalAssets_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/TrancheWrapper/Withdraw.fuzz.t.sol
+++ b/test/fuzz/TrancheWrapper/Withdraw.fuzz.t.sol
@@ -9,6 +9,7 @@ import { TrancheErrors } from "../../../src/libraries/Errors.sol";
 /**
  * @notice Fuzz tests for the function "withdraw" of contract "Tranche Wrapper".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract Withdraw_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/liquidators/LiquidatorL1/Bid.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL1/Bid.fuzz.t.sol
@@ -13,7 +13,7 @@ import { stdError } from "../../../../lib/accounts-v2/lib/forge-std/src/StdError
 /**
  * @notice Fuzz tests for the function "bid" of contract "LiquidatorL1".
  */
-// forge-lint: disable-next-item(divide-before-multiply)
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract Bid_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/liquidators/LiquidatorL1/CalculateBidPrice.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL1/CalculateBidPrice.fuzz.t.sol
@@ -11,7 +11,7 @@ import { LogExpMath } from "../../../../src/libraries/LogExpMath.sol";
 /**
  * @notice Fuzz tests for the function "_calculateBidPrice" of contract "LiquidatorL1".
  */
-// forge-lint: disable-next-item(divide-before-multiply)
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract CalculateBidPrice_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/liquidators/LiquidatorL1/CalculateTotalShare.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL1/CalculateTotalShare.fuzz.t.sol
@@ -62,6 +62,7 @@ contract CalculateTotalShare_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
         for (uint256 i; i < assetAmounts.length; ++i) {
             uint256 share = assetShares[i] * askedAssetAmounts[i] / assetAmounts[i];
             // Round up.
+            // forge-lint: disable-next-item(divide-before-multiply)
             if (share * assetAmounts[i] < assetShares[i] * askedAssetAmounts[i]) share += 1;
 
             expectedTotalShare += share;

--- a/test/fuzz/liquidators/LiquidatorL1/EndAuction.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL1/EndAuction.fuzz.t.sol
@@ -13,6 +13,7 @@ import { stdStorage, StdStorage } from "../../../../lib/accounts-v2/lib/forge-st
 /**
  * @notice Fuzz tests for the function "endAuction" of contract "LiquidatorL1".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract EndAuction_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/liquidators/LiquidatorL1/GetAssetShares.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL1/GetAssetShares.fuzz.t.sol
@@ -66,6 +66,7 @@ contract GetAssetShares_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
         for (uint256 i; i < assetValues.length; ++i) {
             expectedValue = assetValues[i].assetValue * ONE_4 / totalValue;
             // Round up.
+            // forge-lint: disable-next-item(divide-before-multiply)
             if (expectedValue * totalValue < assetValues[i].assetValue * ONE_4) expectedValue += 1;
 
             assertEq(assetShares[i], expectedValue);

--- a/test/fuzz/liquidators/LiquidatorL1/GetBidPrice.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL1/GetBidPrice.fuzz.t.sol
@@ -10,7 +10,7 @@ import { stdError } from "../../../../lib/accounts-v2/lib/forge-std/src/StdError
 /**
  * @notice Fuzz tests for the function "getBidPrice" of contract "LiquidatorL1".
  */
-// forge-lint: disable-next-item(divide-before-multiply)
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract GetBidPrice_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/liquidators/LiquidatorL1/SetAuctionCurveParameters.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL1/SetAuctionCurveParameters.fuzz.t.sol
@@ -13,6 +13,7 @@ import { LogExpMath } from "../../../../src/libraries/LogExpMath.sol";
 /**
  * @notice Fuzz tests for the function "setAuctionCurveParameters" of contract "LiquidatorL1".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract SetAuctionCurveParameters_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/liquidators/LiquidatorL1/SettleAuction.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL1/SettleAuction.fuzz.t.sol
@@ -14,6 +14,7 @@ import { stdStorage, StdStorage } from "../../../../lib/accounts-v2/lib/forge-st
  * @dev "_settleAuction" has no own reverts, it returns a bool indicating if a termination condition was met.
  * Each test asserts the returned bool and the side effects of the matched condition.
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract SettleAuction_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/liquidators/LiquidatorL1/SettleUnhappyFlow.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL1/SettleUnhappyFlow.fuzz.t.sol
@@ -29,6 +29,7 @@ contract SettleUnhappyFlow_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
         vm.assume(caller != address(0));
 
         // And: The account auction is initiated.
+        // forge-lint: disable-next-item(unsafe-typecast)
         usedMargin = uint112(bound(usedMargin, uint256(minimumMargin) + 1, type(uint112).max - 1));
         uint112 amountLoaned = usedMargin - minimumMargin;
         initiateLiquidation(minimumMargin, amountLoaned);

--- a/test/fuzz/liquidators/LiquidatorL1/_LiquidatorL1.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL1/_LiquidatorL1.fuzz.t.sol
@@ -24,6 +24,7 @@ import { stdStorage, StdStorage } from "../../../../lib/accounts-v2/lib/forge-st
 /**
  * @notice Common logic needed by all "LiquidatorL1" fuzz tests.
  */
+// forge-lint: disable-next-item(reentrancy-no-eth)
 abstract contract LiquidatorL1_Fuzz_Test is Fuzz_Lending_Test {
     using stdStorage for StdStorage;
 

--- a/test/fuzz/liquidators/LiquidatorL2/Bid.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL2/Bid.fuzz.t.sol
@@ -13,7 +13,7 @@ import { stdError } from "../../../../lib/accounts-v2/lib/forge-std/src/StdError
 /**
  * @notice Fuzz tests for the function "bid" of contract "LiquidatorL2".
  */
-// forge-lint: disable-next-item(divide-before-multiply)
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract Bid_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/liquidators/LiquidatorL2/CalculateBidPrice.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL2/CalculateBidPrice.fuzz.t.sol
@@ -11,7 +11,7 @@ import { LogExpMath } from "../../../../src/libraries/LogExpMath.sol";
 /**
  * @notice Fuzz tests for the function "_calculateBidPrice" of contract "LiquidatorL2".
  */
-// forge-lint: disable-next-item(divide-before-multiply)
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract CalculateBidPrice_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/liquidators/LiquidatorL2/CalculateTotalShare.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL2/CalculateTotalShare.fuzz.t.sol
@@ -62,6 +62,7 @@ contract CalculateTotalShare_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
         for (uint256 i; i < assetAmounts.length; ++i) {
             uint256 share = assetShares[i] * askedAssetAmounts[i] / assetAmounts[i];
             // Round up.
+            // forge-lint: disable-next-item(divide-before-multiply)
             if (share * assetAmounts[i] < assetShares[i] * askedAssetAmounts[i]) share += 1;
 
             expectedTotalShare += share;

--- a/test/fuzz/liquidators/LiquidatorL2/EndAuction.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL2/EndAuction.fuzz.t.sol
@@ -12,7 +12,7 @@ import { LiquidatorErrors } from "../../../../src/libraries/Errors.sol";
 /**
  * @notice Fuzz tests for the function "endAuction" of contract "LiquidatorL2".
  */
-// forge-lint: disable-next-item(divide-before-multiply)
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract EndAuction_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/liquidators/LiquidatorL2/GetAssetShares.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL2/GetAssetShares.fuzz.t.sol
@@ -66,6 +66,7 @@ contract GetAssetShares_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
         for (uint256 i; i < assetValues.length; ++i) {
             expectedValue = assetValues[i].assetValue * ONE_4 / totalValue;
             // Round up.
+            // forge-lint: disable-next-item(divide-before-multiply)
             if (expectedValue * totalValue < assetValues[i].assetValue * ONE_4) expectedValue += 1;
 
             assertEq(assetShares[i], expectedValue);

--- a/test/fuzz/liquidators/LiquidatorL2/GetBidPrice.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL2/GetBidPrice.fuzz.t.sol
@@ -10,7 +10,7 @@ import { stdError } from "../../../../lib/accounts-v2/lib/forge-std/src/StdError
 /**
  * @notice Fuzz tests for the function "getBidPrice" of contract "LiquidatorL2".
  */
-// forge-lint: disable-next-item(divide-before-multiply)
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract GetBidPrice_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/liquidators/LiquidatorL2/SetAuctionCurveParameters.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL2/SetAuctionCurveParameters.fuzz.t.sol
@@ -13,6 +13,7 @@ import { LogExpMath } from "../../../../src/libraries/LogExpMath.sol";
 /**
  * @notice Fuzz tests for the function "setAuctionCurveParameters" of contract "LiquidatorL2".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract SetAuctionCurveParameters_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/liquidators/LiquidatorL2/SettleAuction.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL2/SettleAuction.fuzz.t.sol
@@ -14,6 +14,7 @@ import { stdStorage, StdStorage } from "../../../../lib/accounts-v2/lib/forge-st
  * @dev "_settleAuction" has no own reverts, it returns a bool indicating if a termination condition was met.
  * Each test asserts the returned bool and the side effects of the matched condition.
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract SettleAuction_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/liquidators/LiquidatorL2/SettleUnhappyFlow.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL2/SettleUnhappyFlow.fuzz.t.sol
@@ -33,6 +33,7 @@ contract SettleUnhappyFlow_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
         vm.assume(caller != address(0));
 
         // And: The account auction is initiated.
+        // forge-lint: disable-next-item(unsafe-typecast)
         usedMargin = uint112(bound(usedMargin, uint256(minimumMargin) + 1, type(uint112).max - 1));
         uint112 amountLoaned = usedMargin - minimumMargin;
         initiateLiquidation(minimumMargin, amountLoaned);

--- a/test/scenario/LeveragedActions.scenario.t.sol
+++ b/test/scenario/LeveragedActions.scenario.t.sol
@@ -21,6 +21,7 @@ import { LendingPoolErrors } from "../../src/libraries/Errors.sol";
 /**
  * @notice Scenario tests for With Leveraged Actions flows.
  */
+// forge-lint: disable-next-item(divide-before-multiply)
 contract LeveragedActions_Scenario_Test is Scenario_Lending_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////

--- a/test/utils/fixtures/arcadia-lending/ArcadiaLendingFixture.f.sol
+++ b/test/utils/fixtures/arcadia-lending/ArcadiaLendingFixture.f.sol
@@ -12,6 +12,7 @@ import { LendingPoolExtension } from "../../extensions/LendingPoolExtension.sol"
 import { LiquidatorL2Extension } from "../../extensions/LiquidatorL2Extension.sol";
 import { TrancheExtension } from "../../extensions/TrancheExtension.sol";
 
+// forge-lint: disable-next-item(reentrancy-no-eth)
 contract ArcadiaLendingFixture is Base_Lending_Test {
     function deployArcadiaLending(address numeraire) internal {
         vm.startPrank(users.owner);

--- a/test/utils/mocks/Bidder.sol
+++ b/test/utils/mocks/Bidder.sol
@@ -5,5 +5,6 @@
 pragma solidity ^0.8.0;
 
 contract Bidder {
+    // forge-lint: disable-next-item(empty-block)
     function bidCallback(uint256[] memory assetAmounts, uint256 price, bytes calldata data) external { }
 }


### PR DESCRIPTION
Mark the forge 1.8 lint findings that are intentional with inline directives, per site in src and at contract level in the tests. Rules that fire across the whole codebase go in exclude_lints instead.

Needs forge 1.8.1, directives on findings reported in an inherited file were ignored before that.

Also drops dynamic_test_linking = false and unchecked_cheatcode_artifacts = true. Both were only needed because the artifact lookup broke when the artifact list is disabled, see foundry-rs/foundry#16468.
