### PR TITLE
👷 Only check out the submodules that are compiled

### DIFF
--- a/.github/workflows/foundryFuzz.yml
+++ b/.github/workflows/foundryFuzz.yml
@@ -10,9 +10,13 @@ jobs:
     name: Foundry project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: recursive
+      - uses: actions/checkout@v5
+
+      - name: Check out the submodules that are compiled
+        run: |
+          git submodule update --init
+          git -C lib/accounts-v2 submodule update --init
+          git -C lib/accounts-v2 submodule update --init --recursive lib/slipstream lib/v4-periphery
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,11 +13,11 @@ jobs:
     name: Foundry project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Main Checkout
         env:
           SSH_KEY_FOR_SUBMODULE: ${{secrets.ACCOUNT_V2_DEPLOY_KEY}}
-        run: mkdir $HOME/.ssh && echo "$SSH_KEY_FOR_SUBMODULE" > $HOME/.ssh/id_rsa && chmod 600 $HOME/.ssh/id_rsa && git submodule update --init --recursive
+        run: mkdir $HOME/.ssh && echo "$SSH_KEY_FOR_SUBMODULE" > $HOME/.ssh/id_rsa && chmod 600 $HOME/.ssh/id_rsa && git submodule update --init && git -C lib/accounts-v2 submodule update --init && git -C lib/accounts-v2 submodule update --init --recursive lib/slipstream lib/v4-periphery
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1


### PR DESCRIPTION
CI cloned the whole recursive submodule tree. Check out only the submodules that are compiled, matching accounts-v2#354.

- `git submodule update --init` at the top level
- recurse only into `lib/slipstream` and `lib/v4-periphery` under accounts-v2
- `actions/checkout@v5`

Applies to both `test.yml` and `foundryFuzz.yml`.