### PR TITLE
♻️ Bound fuzz inputs instead of rejecting them

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -15,7 +15,7 @@ fs_permissions = [{ access = "write", path = "./script/out"}]
 # - 3860: Contract initcode size exceeds 49152 bytes
 # - 4591: More than 256 warnings (meta-warning triggered by suppressed max size warnings)
 # - 5574: Contract code size exceeds 24576 bytes
-ignored_error_codes = [2424, 3860, 4591, 5574, 8429]
+ignored_error_codes = [2394, 2424, 3860, 4591, 5574, 8429]
 
 [profile.lite]
 src = 'src'
@@ -37,11 +37,22 @@ tab_width = 4
 exclude_lints = [
     "asm-keccak256",
     "calls-loop",
+    "costly-loop",
+    "inline-assembly",
+    "internal-function-used-once",
+    "literal-instead-of-constant",
+    "low-level-calls",
     "missing-events-access-control",
+    "missing-inheritance",
     "missing-zero-check",
+    "multi-contract-file",
+    "non-reentrant-not-first",
+    "pragma-inconsistent",
     "reentrancy-events",
+    "require-revert-in-loop",
     "uninitialized-local",
     "unsafe-cheatcode",
+    "unused-error",
     "unused-return",
     "unwrapped-modifier-logic",
 ]

--- a/src/LendingPool.sol
+++ b/src/LendingPool.sol
@@ -144,6 +144,7 @@ contract LendingPool is LendingPoolGuardian, Creditor, DebtToken, ILendingPool {
     event LiquidationWeightTrancheUpdated(uint16 liquidationWeight);
     event PoolStateUpdated(uint256 totalDebt, uint256 totalLiquidity, uint80 interestRate);
     event Repay(address indexed account, address indexed from, uint256 amount);
+    // forge-lint: disable-next-item(event-fields)
     event TranchePopped(address tranche);
     event TreasuryWeightsUpdated(uint16 interestWeight, uint16 liquidationWeight);
 
@@ -162,6 +163,7 @@ contract LendingPool is LendingPoolGuardian, Creditor, DebtToken, ILendingPool {
     /**
      * @notice Checks if caller is a Tranche.
      */
+    // forge-lint: disable-next-item(modifier-used-only-once)
     modifier onlyTranche() {
         if (!isTranche[msg.sender]) revert LendingPoolErrors.Unauthorized();
         _;

--- a/src/guardians/LendingPoolGuardian.sol
+++ b/src/guardians/LendingPoolGuardian.sol
@@ -49,6 +49,7 @@ abstract contract LendingPoolGuardian is BaseGuardian {
     /**
      * @dev Throws if the repay functionality is paused.
      */
+    // forge-lint: disable-next-item(modifier-used-only-once)
     modifier whenRepayNotPaused() {
         if (repayPaused) revert GuardianErrors.FunctionIsPaused();
         _;
@@ -57,6 +58,7 @@ abstract contract LendingPoolGuardian is BaseGuardian {
     /**
      * @dev Throws if the withdraw functionality is paused.
      */
+    // forge-lint: disable-next-item(modifier-used-only-once)
     modifier whenWithdrawNotPaused() {
         if (withdrawPaused) revert GuardianErrors.FunctionIsPaused();
         _;

--- a/src/libraries/BalancerErrors.sol
+++ b/src/libraries/BalancerErrors.sol
@@ -29,6 +29,7 @@ function _require(bool condition, uint256 errorCode) pure {
 /**
  * @dev Reverts with a revert reason containing `errorCode`. Only codes up to 999 are supported.
  */
+// forge-lint: disable-next-item(too-many-digits)
 function _revert(uint256 errorCode) pure {
     // We're going to dynamically create a revert string based on the error code, with the following format:
     // 'BAL#{errorCode}'

--- a/src/libraries/LogExpMath.sol
+++ b/src/libraries/LogExpMath.sol
@@ -145,6 +145,7 @@ library LogExpMath {
      *
      * Reverts if `x` is smaller than MIN_NATURAL_EXPONENT, or larger than `MAX_NATURAL_EXPONENT`.
      */
+    // forge-lint: disable-next-item(cyclomatic-complexity)
     function exp(int256 x) internal pure returns (int256) {
         _require(x >= MIN_NATURAL_EXPONENT && x <= MAX_NATURAL_EXPONENT, Errors.INVALID_EXPONENT);
 
@@ -285,6 +286,7 @@ library LogExpMath {
     /**
      * @dev Internal natural logarithm (ln(a)) with signed 18 decimal fixed point argument.
      */
+    // forge-lint: disable-next-item(cyclomatic-complexity)
     function _ln(int256 a) private pure returns (int256) {
         if (a < ONE_18) {
             // Since ln(a^k) = k * ln(a), we can compute ln(a) as ln(a) = ln((1/a)^(-1)) = - ln((1/a)). If a is less

--- a/test/fuzz/DebtToken/Deposit.fuzz.t.sol
+++ b/test/fuzz/DebtToken/Deposit.fuzz.t.sol
@@ -33,7 +33,7 @@ contract Deposit_DebtToken_Fuzz_Test is DebtToken_Fuzz_Test {
     }
 
     function testFuzz_Success_deposit_Internal_FirstDeposit(uint256 assets, address receiver) public {
-        vm.assume(assets > 0);
+        assets = bound(assets, 1, type(uint256).max);
 
         debt_.deposit_(assets, receiver);
 
@@ -48,11 +48,11 @@ contract Deposit_DebtToken_Fuzz_Test is DebtToken_Fuzz_Test {
         uint256 totalSupply,
         uint256 totalDebt
     ) public {
-        vm.assume(assets <= totalDebt);
-        vm.assume(assets <= type(uint256).max - totalDebt);
-        vm.assume(assets > 0);
-        vm.assume(totalSupply > 0); //Not first deposit
-        vm.assume(assets <= type(uint256).max / totalSupply); //Avoid overflow in next assumption
+        totalDebt = bound(totalDebt, 1, type(uint256).max / 2);
+        totalSupply = bound(totalSupply, 1, type(uint256).max);
+        // Avoid overflow of the shares calculation.
+        uint256 maxAssets = type(uint256).max / totalSupply;
+        assets = bound(assets, 1, totalDebt < maxAssets ? totalDebt : maxAssets);
 
         stdstore.target(address(debt_)).sig(debt_.totalSupply.selector).checked_write(totalSupply);
 

--- a/test/fuzz/DebtToken/Withdraw.fuzz.t.sol
+++ b/test/fuzz/DebtToken/Withdraw.fuzz.t.sol
@@ -38,12 +38,11 @@ contract Withdraw_DebtToken_Fuzz_Test is DebtToken_Fuzz_Test {
         uint256 totalSupply,
         uint256 totalDebt
     ) public {
-        vm.assume(assets <= totalDebt);
-        vm.assume(totalSupply > 0); //First mint new shares are issued equal to amount of assets -> error will not throw
-        vm.assume(assets <= type(uint256).max / totalSupply); //Avoid overflow in next assumption
+        totalSupply = bound(totalSupply, 1, type(uint256).max);
+        totalDebt = bound(totalDebt, 1, type(uint256).max);
 
         //Will result in zero shares being created
-        vm.assume(totalDebt > assets * totalSupply);
+        assets = bound(assets, 0, (totalDebt - 1) / totalSupply);
 
         stdstore.target(address(debt_)).sig(debt_.totalSupply.selector).checked_write(totalSupply);
         debt_.setRealisedDebt(totalDebt);
@@ -63,15 +62,20 @@ contract Withdraw_DebtToken_Fuzz_Test is DebtToken_Fuzz_Test {
         uint256 totalSupply,
         uint256 totalDebt
     ) public {
-        vm.assume(assetsWithdrawn <= totalDebt);
-        vm.assume(totalDebt > 0);
-        vm.assume(initialShares <= totalSupply);
-        vm.assume(totalSupply > 0);
-        vm.assume(assetsWithdrawn <= type(uint256).max / totalSupply); //Avoid overflow in next assumption
-        vm.assume(totalDebt <= assetsWithdrawn * totalSupply);
+        totalSupply = bound(totalSupply, 1, type(uint256).max);
+        totalDebt = bound(totalDebt, 1, type(uint256).max);
+
+        // Shares are created, and "assetsWithdrawn * totalSupply" does not overflow.
+        uint256 minAssets = totalDebt / totalSupply;
+        if (totalDebt % totalSupply != 0) minAssets += 1;
+        uint256 maxAssets = type(uint256).max / totalSupply;
+        if (maxAssets > totalDebt) maxAssets = totalDebt;
+        vm.assume(minAssets <= maxAssets);
+        assetsWithdrawn = bound(assetsWithdrawn, minAssets, maxAssets);
 
         uint256 sharesRedeemed = assetsWithdrawn * totalSupply / totalDebt;
-        vm.assume(sharesRedeemed <= initialShares);
+        vm.assume(sharesRedeemed <= totalSupply);
+        initialShares = bound(initialShares, sharesRedeemed, totalSupply);
 
         stdstore.target(address(debt_)).sig(debt_.balanceOf.selector).with_key(owner).checked_write(initialShares);
         stdstore.target(address(debt_)).sig(debt_.totalSupply.selector).checked_write(totalSupply);

--- a/test/fuzz/LendingPool/AuctionRepay.fuzz.t.sol
+++ b/test/fuzz/LendingPool/AuctionRepay.fuzz.t.sol
@@ -48,11 +48,10 @@ contract AuctionRepay_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         address sender
     ) public {
         // Given: collateralValue is smaller than maxExposure.
-        amountLoaned = uint112(bound(amountLoaned, 0, type(uint112).max - 1));
+        amountLoaned = uint112(bound(amountLoaned, 2, type(uint112).max - 1));
 
-        vm.assume(amountLoaned > availableFunds);
-        vm.assume(amountLoaned <= type(uint256).max / AssetValuationLib.ONE_4); // No overflow Risk Module
-        vm.assume(availableFunds > 0);
+        // And: The sender has insufficient funds to repay the loan.
+        availableFunds = bound(availableFunds, 1, amountLoaned - 1);
         vm.assume(sender != address(0));
         vm.assume(sender != users.liquidityProvider);
         vm.assume(sender != users.accountOwner);
@@ -80,11 +79,10 @@ contract AuctionRepay_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
 
     function testFuzz_Revert_auctionRepay_Paused(uint112 amountLoaned, uint256 availableFunds, address sender) public {
         // Given: collateralValue is smaller than maxExposure.
-        amountLoaned = uint112(bound(amountLoaned, 0, type(uint112).max - 1));
+        amountLoaned = uint112(bound(amountLoaned, 2, type(uint112).max - 1));
 
-        vm.assume(amountLoaned > availableFunds);
-        vm.assume(amountLoaned <= type(uint256).max / AssetValuationLib.ONE_4); // No overflow Risk Module
-        vm.assume(availableFunds > 0);
+        // And: The sender has insufficient funds to repay the loan.
+        availableFunds = bound(availableFunds, 1, amountLoaned - 1);
         vm.assume(sender != address(0));
         vm.assume(sender != users.liquidityProvider);
         vm.assume(sender != users.accountOwner);
@@ -122,8 +120,11 @@ contract AuctionRepay_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         address nonAccount
     ) public {
         vm.assume(nonAccount != address(account));
-        vm.assume(availableFunds > amountRepaid);
         vm.assume(sender != users.liquidityProvider);
+
+        // Given: The bidder has sufficient funds.
+        availableFunds = uint128(bound(availableFunds, 1, type(uint128).max));
+        amountRepaid = bound(amountRepaid, 0, availableFunds - 1);
         vm.prank(users.liquidityProvider);
         // forge-lint: disable-next-line(erc20-unchecked-transfer)
         mockERC20.stable1.transfer(sender, availableFunds);

--- a/test/fuzz/LendingPool/AuctionRepay.fuzz.t.sol
+++ b/test/fuzz/LendingPool/AuctionRepay.fuzz.t.sol
@@ -6,7 +6,6 @@ pragma solidity ^0.8.0;
 
 import { LendingPool_Fuzz_Test } from "./_LendingPool.fuzz.t.sol";
 
-import { AssetValuationLib } from "../../../lib/accounts-v2/src/libraries/AssetValuationLib.sol";
 import { DebtTokenErrors } from "../../../src/libraries/Errors.sol";
 import { GuardianErrors } from "../../../lib/accounts-v2/src/libraries/Errors.sol";
 import { LendingPool } from "../../../src/LendingPool.sol";

--- a/test/fuzz/LendingPool/Borrow.fuzz.t.sol
+++ b/test/fuzz/LendingPool/Borrow.fuzz.t.sol
@@ -39,7 +39,7 @@ contract Borrow_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     }
 
     function testFuzz_Revert_borrow_NonAccount(uint256 amount, address nonAccount, address to) public {
-        vm.assume(amount > 0);
+        amount = bound(amount, 1, type(uint256).max);
 
         vm.assume(nonAccount != address(account));
         vm.expectRevert(LendingPoolErrors.IsNotAnAccount.selector);
@@ -47,10 +47,9 @@ contract Borrow_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     }
 
     function testFuzz_Revert_borrow_Unauthorised(uint256 amount, address beneficiary, address to) public {
-        vm.assume(amount > 0);
+        amount = bound(amount, 1, type(uint256).max);
         vm.assume(beneficiary != users.accountOwner);
 
-        vm.assume(amount > 0);
         vm.startPrank(beneficiary);
         vm.expectRevert(stdError.arithmeticError);
         pool.borrow(amount, address(account), to, emptyBytes3);
@@ -64,8 +63,8 @@ contract Borrow_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         address to
     ) public {
         vm.assume(beneficiary != users.accountOwner);
-        vm.assume(amountLoaned > 0);
-        vm.assume(amountAllowed < amountLoaned);
+        amountLoaned = bound(amountLoaned, 1, type(uint256).max);
+        amountAllowed = bound(amountAllowed, 0, amountLoaned - 1);
 
         vm.prank(users.accountOwner);
         pool.approveBeneficiary(beneficiary, amountAllowed, address(account));
@@ -85,7 +84,7 @@ contract Borrow_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         vm.assume(beneficiary != newOwner);
         vm.assume(newOwner != users.accountOwner);
         vm.assume(newOwner != address(0));
-        vm.assume(amountLoaned > 0);
+        amountLoaned = uint128(bound(amountLoaned, 1, type(uint128).max));
 
         vm.prank(users.accountOwner);
         pool.approveBeneficiary(beneficiary, type(uint256).max, address(account));
@@ -106,8 +105,7 @@ contract Borrow_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         // Given: collateralValue is smaller than maxExposure.
         collateralValue = uint112(bound(collateralValue, 0, type(uint112).max - 1));
 
-        vm.assume(collateralValue < amountLoaned);
-        vm.assume(amountLoaned > 0);
+        amountLoaned = uint128(bound(amountLoaned, uint256(collateralValue) + 1, type(uint128).max));
 
         depositErc20InAccount(account, mockERC20.stable1, collateralValue);
 
@@ -126,8 +124,8 @@ contract Borrow_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         // Given: collateralValue is smaller than maxExposure.
         collateralValue = uint112(bound(collateralValue, 0, type(uint112).max - 1));
 
-        vm.assume(collateralValue >= amountLoaned);
-        vm.assume(amountLoaned > 0);
+        collateralValue = uint112(bound(collateralValue, 1, type(uint112).max - 1));
+        amountLoaned = uint128(bound(amountLoaned, 1, collateralValue));
         vm.assume(trustedCreditor_ != address(pool));
 
         depositErc20InAccount(account, mockERC20.stable1, collateralValue);
@@ -168,8 +166,8 @@ contract Borrow_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         // Given: collateralValue is smaller than maxExposure.
         collateralValue = uint112(bound(collateralValue, 0, type(uint112).max - 1));
 
-        vm.assume(collateralValue >= amountLoaned);
-        vm.assume(amountLoaned > 0);
+        collateralValue = uint112(bound(collateralValue, 1, type(uint112).max - 1));
+        amountLoaned = uint128(bound(amountLoaned, 1, collateralValue));
 
         depositErc20InAccount(account, mockERC20.stable1, collateralValue);
 
@@ -191,10 +189,9 @@ contract Borrow_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         // Given: collateralValue is smaller than maxExposure.
         collateralValue = uint112(bound(collateralValue, 0, type(uint112).max - 1));
 
-        vm.assume(collateralValue >= amountLoaned);
-        vm.assume(amountLoaned > 0);
-        vm.assume(liquidity < amountLoaned);
-        vm.assume(liquidity > 0);
+        collateralValue = uint112(bound(collateralValue, 2, type(uint112).max - 1));
+        amountLoaned = uint128(bound(amountLoaned, 2, collateralValue));
+        liquidity = uint128(bound(liquidity, 1, uint256(amountLoaned) - 1));
         vm.assume(to != address(0));
 
         vm.prank(address(srTranche));
@@ -213,10 +210,8 @@ contract Borrow_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         // Given: collateralValue is smaller than maxExposure.
         collateralValue = uint112(bound(collateralValue, 0, type(uint112).max - 1));
 
-        vm.assume(collateralValue <= amountLoaned);
-        vm.assume(amountLoaned > 0);
-        vm.assume(liquidity > amountLoaned);
-        vm.assume(liquidity > 0);
+        amountLoaned = uint128(bound(amountLoaned, collateralValue == 0 ? 1 : collateralValue, type(uint128).max - 1));
+        liquidity = uint128(bound(liquidity, uint256(amountLoaned) + 1, type(uint128).max));
         vm.assume(to != address(0));
 
         vm.warp(35 days);
@@ -242,9 +237,9 @@ contract Borrow_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         // Given: collateralValue is smaller than maxExposure.
         collateralValue = uint112(bound(collateralValue, 0, type(uint112).max - 1));
 
-        vm.assume(collateralValue >= amountLoaned);
-        vm.assume(amountLoaned > 0);
-        vm.assume(liquidity >= amountLoaned);
+        collateralValue = uint112(bound(collateralValue, 1, type(uint112).max - 1));
+        amountLoaned = uint128(bound(amountLoaned, 1, collateralValue));
+        liquidity = uint128(bound(liquidity, amountLoaned, type(uint128).max));
         vm.assume(to != address(0));
         vm.assume(to != users.liquidityProvider);
         vm.assume(to != address(pool));
@@ -276,11 +271,10 @@ contract Borrow_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         // Given: collateralValue is smaller than maxExposure.
         collateralValue = uint112(bound(collateralValue, 0, type(uint112).max - 1));
 
-        vm.assume(amountAllowed >= amountLoaned);
-        vm.assume(collateralValue >= amountLoaned);
-        vm.assume(amountLoaned > 0);
-        vm.assume(liquidity >= amountLoaned);
-        vm.assume(amountAllowed < type(uint256).max);
+        collateralValue = uint112(bound(collateralValue, 1, type(uint112).max - 1));
+        amountLoaned = uint128(bound(amountLoaned, 1, collateralValue));
+        amountAllowed = uint128(bound(amountAllowed, amountLoaned, type(uint128).max));
+        liquidity = uint128(bound(liquidity, amountLoaned, type(uint128).max));
         vm.assume(beneficiary != users.accountOwner);
         vm.assume(to != address(0));
         vm.assume(to != users.liquidityProvider);
@@ -313,9 +307,9 @@ contract Borrow_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         // Given: collateralValue is smaller than maxExposure.
         collateralValue = uint112(bound(collateralValue, 0, type(uint112).max - 1));
 
-        vm.assume(collateralValue >= amountLoaned);
-        vm.assume(amountLoaned > 0);
-        vm.assume(liquidity >= amountLoaned);
+        collateralValue = uint112(bound(collateralValue, 1, type(uint112).max - 1));
+        amountLoaned = uint128(bound(amountLoaned, 1, collateralValue));
+        liquidity = uint128(bound(liquidity, amountLoaned, type(uint128).max));
         vm.assume(beneficiary != users.accountOwner);
         vm.assume(to != address(0));
         vm.assume(to != users.liquidityProvider);
@@ -349,10 +343,14 @@ contract Borrow_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         // Given: collateralValue is smaller than maxExposure.
         collateralValue = uint112(bound(collateralValue, type(uint96).max, type(uint112).max - 1));
 
-        vm.assume(collateralValue >= uint256(amountLoaned) + (uint256(amountLoaned).mulDivDown(originationFee, 10_000)));
-        vm.assume(amountLoaned > 0);
-        vm.assume(liquidity >= amountLoaned);
-        vm.assume(liquidity <= type(uint128).max - (uint256(amountLoaned).mulDivUp(originationFee, 10_000)));
+        // And: The loan and its origination fee stay below the collateral value.
+        amountLoaned =
+            uint128(bound(amountLoaned, 1, uint256(collateralValue) * 10_000 / (10_000 + uint256(originationFee))));
+
+        // And: There is sufficient liquidity and the origination fee does not overflow.
+        liquidity = uint128(
+            bound(liquidity, amountLoaned, type(uint128).max - uint256(amountLoaned).mulDivUp(originationFee, 10_000))
+        );
         vm.assume(to != address(0));
         vm.assume(to != users.liquidityProvider);
         vm.assume(to != address(pool));
@@ -400,11 +398,14 @@ contract Borrow_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         bytes3 ref
     ) public {
         // Given: collateralValue is smaller than maxExposure.
-        collateralValue = uint112(bound(collateralValue, 0, type(uint112).max - 1));
+        collateralValue = uint112(bound(collateralValue, 2, type(uint112).max - 1));
 
-        vm.assume(collateralValue >= uint256(amountLoaned) + (uint256(amountLoaned) * originationFee / 10_000));
-        vm.assume(liquidity >= amountLoaned);
-        vm.assume(amountLoaned > 0);
+        // And: The loan and its origination fee stay below the collateral value.
+        amountLoaned =
+            uint128(bound(amountLoaned, 1, uint256(collateralValue) * 10_000 / (10_000 + uint256(originationFee))));
+
+        // And: There is sufficient liquidity.
+        liquidity = uint128(bound(liquidity, amountLoaned, type(uint128).max));
         vm.assume(to != address(0));
         vm.assume(to != users.liquidityProvider);
         vm.assume(to != address(pool));

--- a/test/fuzz/LendingPool/CalcUnrealisedDebt.fuzz.t.sol
+++ b/test/fuzz/LendingPool/CalcUnrealisedDebt.fuzz.t.sol
@@ -9,6 +9,7 @@ import { LendingPool_Fuzz_Test } from "./_LendingPool.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "calcUnrealisedDebt" of contract "LendingPool".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract CalcUnrealisedDebt_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -26,11 +27,10 @@ contract CalcUnrealisedDebt_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     {
         // Given: deltaTimestamp smaller than equal to 5 years,
         // realisedDebt smaller than equal to than 3402823669209384912995114146594816
-        vm.assume(deltaTimestamp <= 5 * 365 * 24 * 60 * 60);
         //5 year
-        vm.assume(interestRate <= 10 * 10 ** 18);
+        interestRate = uint80(bound(interestRate, 0, 10 * 10 ** 18));
         //1000%
-        vm.assume(realisedDebt <= type(uint128).max / (10 ** 5));
+        realisedDebt = uint128(bound(realisedDebt, 0, type(uint128).max / (10 ** 5)));
         //highest possible debt at 1000% over 5 years: 3402823669209384912995114146594816
 
         pool.setInterestRate(interestRate);

--- a/test/fuzz/LendingPool/CloseMarginAccount.fuzz.t.sol
+++ b/test/fuzz/LendingPool/CloseMarginAccount.fuzz.t.sol
@@ -26,10 +26,9 @@ contract CloseMarginAccount_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     function testFuzz_Revert_closeMarginAccount_OpenPositionNonZero(uint112 amountLoaned) public {
         // Given: collateralValue is smaller than maxExposure.
         // forge-lint: disable-next-item(unsafe-typecast)
-        amountLoaned = uint112(bound(amountLoaned, 0, type(uint112).max - 1));
+        amountLoaned = uint112(bound(amountLoaned, 0 + 1, type(uint112).max - 1));
 
         // Given: an Account has taken out debt
-        vm.assume(amountLoaned > 0);
 
         vm.prank(address(srTranche));
         pool.depositInLendingPool(amountLoaned, users.liquidityProvider);

--- a/test/fuzz/LendingPool/DepositInLendingPool.fuzz.t.sol
+++ b/test/fuzz/LendingPool/DepositInLendingPool.fuzz.t.sol
@@ -12,6 +12,7 @@ import { LendingPoolErrors } from "../../../src/libraries/Errors.sol";
 /**
  * @notice Fuzz tests for the function "depositInLendingPool" of contract "LendingPool".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract DepositInLendingPool_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -37,7 +38,7 @@ contract DepositInLendingPool_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     }
 
     function testFuzz_Revert_depositInLendingPool_NotApproved(uint128 amount) public {
-        vm.assume(amount > 0);
+        amount = uint128(bound(amount, 1, type(uint128).max));
         vm.prank(users.liquidityProvider);
         mockERC20.stable1.approve(address(pool), 0);
 
@@ -48,7 +49,7 @@ contract DepositInLendingPool_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     }
 
     function testFuzz_Revert_depositInLendingPool_Paused(uint128 amount0, uint128 amount1) public {
-        vm.assume(amount0 <= type(uint128).max - amount1);
+        amount0 = uint128(bound(amount0, 0, type(uint128).max - amount1));
 
         vm.warp(35 days);
         vm.prank(users.guardian);
@@ -64,7 +65,7 @@ contract DepositInLendingPool_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     }
 
     function testFuzz_Success_depositInLendingPool_FirstDepositByTranche(uint256 amount) public {
-        vm.assume(amount <= type(uint128).max);
+        amount = bound(amount, 0, type(uint128).max);
         vm.prank(address(srTranche));
         pool.depositInLendingPool(amount, users.liquidityProvider);
 
@@ -74,7 +75,7 @@ contract DepositInLendingPool_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     }
 
     function testFuzz_Success_depositInLendingPool_MultipleDepositsByTranches(uint128 amount0, uint128 amount1) public {
-        vm.assume(amount0 <= type(uint128).max - amount1);
+        amount0 = uint128(bound(amount0, 0, type(uint128).max - amount1));
 
         uint256 totalAmount = uint256(amount0) + uint256(amount1);
 

--- a/test/fuzz/LendingPool/DonateToTranche.fuzz.t.sol
+++ b/test/fuzz/LendingPool/DonateToTranche.fuzz.t.sol
@@ -13,6 +13,7 @@ import { Tranche } from "../../../src/Tranche.sol";
 /**
  * @notice Fuzz tests for the function "donateToTranche" of contract "LendingPool".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract DonateToTranche_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -26,7 +27,7 @@ contract DonateToTranche_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
                               TESTS
     //////////////////////////////////////////////////////////////*/
     function testFuzz_Revert_donateToTranche_indexIsNoTranche(uint256 index) public {
-        vm.assume(index >= pool.numberOfTranches());
+        index = bound(index, pool.numberOfTranches(), type(uint256).max);
 
         vm.expectRevert(stdError.indexOOBError);
         pool.donateToTranche(index, 1);
@@ -40,9 +41,9 @@ contract DonateToTranche_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     function testFuzz_Success_donateToTranche(uint8 index, uint128 assets, address donator, uint128 initialShares)
         public
     {
-        vm.assume(assets > 0);
-        vm.assume(assets <= type(uint128).max - pool.totalLiquidity() - initialShares);
-        vm.assume(index < pool.numberOfTranches());
+        initialShares = uint128(bound(initialShares, 0, type(uint128).max - pool.totalLiquidity() - 1));
+        assets = uint128(bound(assets, 1, type(uint128).max - pool.totalLiquidity() - initialShares));
+        index = uint8(bound(index, 0, pool.numberOfTranches() - 1));
 
         address tranche_ = pool.getTranches(index);
         vm.startPrank(users.liquidityProvider);

--- a/test/fuzz/LendingPool/FlashAction.fuzz.t.sol
+++ b/test/fuzz/LendingPool/FlashAction.fuzz.t.sol
@@ -82,7 +82,7 @@ contract FlashAction_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         bytes calldata actionData
     ) public {
         vm.assume(beneficiary != users.accountOwner);
-        vm.assume(amountAllowed < type(uint256).max);
+        amountAllowed = bound(amountAllowed, 0, type(uint256).max - 1);
 
         vm.prank(users.accountOwner);
         pool.approveBeneficiary(beneficiary, amountAllowed, address(account));
@@ -99,11 +99,13 @@ contract FlashAction_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         uint128 liquidity
     ) public {
         // Given: collateralValue is smaller than maxExposure.
-        collateralValue = uint112(bound(collateralValue, 0, type(uint112).max - 1));
+        collateralValue = uint112(bound(collateralValue, 2, type(uint112).max - 1));
 
-        vm.assume(collateralValue >= amountLoaned);
-        vm.assume(liquidity < amountLoaned);
-        vm.assume(liquidity > 0);
+        // And: The loan is covered by the collateral.
+        amountLoaned = uint128(bound(amountLoaned, 2, collateralValue));
+
+        // And: There is insufficient liquidity for the loan.
+        liquidity = uint128(bound(liquidity, 1, uint256(amountLoaned) - 1));
 
         vm.prank(address(srTranche));
         pool.depositInLendingPool(liquidity, users.liquidityProvider);
@@ -121,11 +123,13 @@ contract FlashAction_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         uint128 liquidity
     ) public {
         // Given: collateralValue is smaller than maxExposure.
-        collateralValue = uint112(bound(collateralValue, 0, type(uint112).max - 1));
+        collateralValue = uint112(bound(collateralValue, 1, type(uint112).max - 1));
 
-        vm.assume(collateralValue >= amountLoaned);
-        vm.assume(liquidity >= amountLoaned);
-        vm.assume(amountLoaned > 0);
+        // And: The loan is covered by the collateral.
+        amountLoaned = uint128(bound(amountLoaned, 1, collateralValue));
+
+        // And: There is sufficient liquidity.
+        liquidity = uint128(bound(liquidity, amountLoaned, type(uint128).max));
 
         depositErc20InAccount(account, mockERC20.stable1, collateralValue);
 
@@ -150,11 +154,13 @@ contract FlashAction_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         address beneficiary
     ) public {
         // Given: collateralValue is smaller than maxExposure.
-        collateralValue = uint112(bound(collateralValue, 0, type(uint112).max - 1));
+        collateralValue = uint112(bound(collateralValue, 1, type(uint112).max - 1));
 
-        vm.assume(collateralValue >= amountLoaned);
-        vm.assume(liquidity >= amountLoaned);
-        vm.assume(amountLoaned > 0);
+        // And: The loan is covered by the collateral.
+        amountLoaned = uint128(bound(amountLoaned, 1, collateralValue));
+
+        // And: There is sufficient liquidity.
+        liquidity = uint128(bound(liquidity, amountLoaned, type(uint128).max));
         vm.assume(beneficiary != users.accountOwner);
 
         depositErc20InAccount(account, mockERC20.stable1, collateralValue);
@@ -183,10 +189,14 @@ contract FlashAction_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         // Given: collateralValue is smaller than maxExposure.
         collateralValue = uint112(bound(collateralValue, type(uint96).max, type(uint112).max - 1));
 
-        vm.assume(collateralValue >= uint256(amountLoaned) + (uint256(amountLoaned).mulDivDown(originationFee, 10_000)));
-        vm.assume(liquidity >= amountLoaned);
-        vm.assume(liquidity <= type(uint128).max - (uint256(amountLoaned).mulDivUp(originationFee, 10_000)));
-        vm.assume(amountLoaned > 0);
+        // And: The loan and its origination fee stay below the collateral value.
+        amountLoaned =
+            uint128(bound(amountLoaned, 1, uint256(collateralValue) * 10_000 / (10_000 + uint256(originationFee))));
+
+        // And: There is sufficient liquidity and the origination fee does not overflow.
+        liquidity = uint128(
+            bound(liquidity, amountLoaned, type(uint128).max - uint256(amountLoaned).mulDivUp(originationFee, 10_000))
+        );
 
         vm.prank(users.owner);
         pool.setOriginationFee(originationFee);
@@ -230,11 +240,14 @@ contract FlashAction_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         bytes3 ref
     ) public {
         // Given: collateralValue is smaller than maxExposure.
-        collateralValue = uint112(bound(collateralValue, 0, type(uint112).max - 1));
+        collateralValue = uint112(bound(collateralValue, 2, type(uint112).max - 1));
 
-        vm.assume(collateralValue >= uint256(amountLoaned) + (uint256(amountLoaned) * originationFee / 10_000));
-        vm.assume(liquidity >= amountLoaned);
-        vm.assume(amountLoaned > 0);
+        // And: The loan and its origination fee stay below the collateral value.
+        amountLoaned =
+            uint128(bound(amountLoaned, 1, uint256(collateralValue) * 10_000 / (10_000 + uint256(originationFee))));
+
+        // And: There is sufficient liquidity.
+        liquidity = uint128(bound(liquidity, amountLoaned, type(uint128).max));
 
         vm.prank(users.owner);
         pool.setOriginationFee(0);

--- a/test/fuzz/LendingPool/FlashActionCallback.fuzz.t.sol
+++ b/test/fuzz/LendingPool/FlashActionCallback.fuzz.t.sol
@@ -13,6 +13,7 @@ import { LendingPoolErrors } from "../../../src/libraries/Errors.sol";
 /**
  * @notice Fuzz tests for the function "flashActionCallback" of contract "LendingPool".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract FlashActionCallback_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     using FixedPointMathLib for uint256;
 
@@ -56,8 +57,9 @@ contract FlashActionCallback_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         address sender,
         bytes3 referrer
     ) public {
-        vm.assume(liquidity < amountLoaned);
-        vm.assume(liquidity > 0);
+        // Given: There is insufficient liquidity for the loan.
+        amountLoaned = uint128(bound(amountLoaned, 2, type(uint128).max));
+        liquidity = uint128(bound(liquidity, 1, uint256(amountLoaned) - 1));
 
         vm.prank(address(srTranche));
         pool.depositInLendingPool(liquidity, users.liquidityProvider);
@@ -87,10 +89,14 @@ contract FlashActionCallback_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         vm.assume(actionTarget != address(pool));
         vm.assume(actionTarget != users.treasury);
 
-        vm.assume(liquidity >= amountLoaned);
+        // Given: The loan and its origination fee do not overflow.
+        amountLoaned = uint128(
+            bound(amountLoaned, 1, uint256(type(uint128).max) * 10_000 / (10_000 + uint256(originationFee)) - 1)
+        );
         uint256 fee = uint256(amountLoaned).mulDivUp(originationFee, 10_000);
-        vm.assume(liquidity <= type(uint128).max - fee);
-        vm.assume(amountLoaned > 0);
+
+        // And: There is sufficient liquidity.
+        liquidity = uint128(bound(liquidity, amountLoaned, type(uint128).max - fee));
 
         vm.prank(users.owner);
         pool.setOriginationFee(originationFee);

--- a/test/fuzz/LendingPool/GetOpenPosition.fuzz.t.sol
+++ b/test/fuzz/LendingPool/GetOpenPosition.fuzz.t.sol
@@ -24,10 +24,9 @@ contract GetOpenPosition_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     function testFuzz_Success_getOpenPosition(uint112 amountLoaned) public {
         // Given: collateralValue is smaller than maxExposure.
         // forge-lint: disable-next-item(unsafe-typecast)
-        amountLoaned = uint112(bound(amountLoaned, 0, type(uint112).max - 1));
+        amountLoaned = uint112(bound(amountLoaned, 0 + 1, type(uint112).max - 1));
 
         // Given: an Account has taken out debt
-        vm.assume(amountLoaned > 0);
 
         vm.prank(address(srTranche));
         pool.depositInLendingPool(amountLoaned, users.liquidityProvider);

--- a/test/fuzz/LendingPool/LiquidityOf.fuzz.t.sol
+++ b/test/fuzz/LendingPool/LiquidityOf.fuzz.t.sol
@@ -47,10 +47,8 @@ contract LiquidityOf_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
 
         // Given: collateralValue is smaller than maxExposure.
         realisedDebt = uint112(bound(realisedDebt, 1, type(uint112).max - 1));
-        vm.assume(deltaTimestamp <= 5 * 365 * 24 * 60 * 60); // 5 year
-        vm.assume(interestRate <= 1e3 * 10 ** 18); // 1000%
-        vm.assume(interestRate > 0);
-        vm.assume(initialLiquidity >= realisedDebt);
+        interestRate = uint80(bound(interestRate, 0 + 1, 1e3 * 10 ** 18));
+        initialLiquidity = uint120(bound(initialLiquidity, realisedDebt, type(uint120).max));
 
         vm.prank(address(srTranche));
         pool.depositInLendingPool(initialLiquidity, users.liquidityProvider);
@@ -97,12 +95,8 @@ contract LiquidityOf_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
 
         // Given: collateralValue is smaller than maxExposure.
         realisedDebt = uint112(bound(realisedDebt, 1, type(uint112).max - 1));
-        vm.assume(deltaTimestamp <= 5 * 365 * 24 * 60 * 60); // 5 year
-        vm.assume(interestRate <= 1e3 * 10 ** 18); // 1000%
-        vm.assume(interestRate > 0);
-        vm.assume(initialLiquidityTranche >= realisedDebt);
-        // forge-lint: disable-next-item(type-based-tautology)
-        vm.assume(initialLiquidityTranche >= 0);
+        interestRate = uint80(bound(interestRate, 0 + 1, 1e3 * 10 ** 18));
+        initialLiquidityTranche = uint120(bound(initialLiquidityTranche, realisedDebt, type(uint120).max));
 
         vm.prank(address(srTranche));
         pool.depositInLendingPool(initialLiquidityTranche, users.liquidityProvider);
@@ -154,10 +148,8 @@ contract LiquidityOf_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
 
         // Given: collateralValue is smaller than maxExposure.
         realisedDebt = uint112(bound(realisedDebt, 1, type(uint112).max - 1));
-        vm.assume(deltaTimestamp <= 5 * 365 * 24 * 60 * 60); // 5 year
-        vm.assume(interestRate <= 1e3 * 10 ** 18); // 1000%
-        vm.assume(interestRate > 0);
-        vm.assume(initialLiquidityTranche >= realisedDebt);
+        interestRate = uint80(bound(interestRate, 0 + 1, 1e3 * 10 ** 18));
+        initialLiquidityTranche = uint120(bound(initialLiquidityTranche, realisedDebt, type(uint120).max));
 
         vm.prank(address(srTranche));
         pool.depositInLendingPool(initialLiquidityTranche, users.liquidityProvider);

--- a/test/fuzz/LendingPool/LiquidityOf.fuzz.t.sol
+++ b/test/fuzz/LendingPool/LiquidityOf.fuzz.t.sol
@@ -36,7 +36,7 @@ contract LiquidityOf_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         uint16 interestWeightTranche,
         uint16 totalInterestWeight
     ) public {
-        // Given interestWeights:
+        // Given: interestWeights:
         totalInterestWeight = uint16(bound(totalInterestWeight, 1, type(uint16).max));
         interestWeightTranche = uint16(bound(interestWeightTranche, 0, totalInterestWeight));
         vm.startPrank(users.owner);
@@ -84,7 +84,7 @@ contract LiquidityOf_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         uint16 interestWeightTreasury,
         uint16 totalInterestWeight
     ) public {
-        // Given interestWeights:
+        // Given: interestWeights:
         totalInterestWeight = uint16(bound(totalInterestWeight, 1, type(uint16).max));
         interestWeightTreasury = uint16(bound(interestWeightTreasury, 0, totalInterestWeight));
         vm.startPrank(users.owner);
@@ -141,7 +141,7 @@ contract LiquidityOf_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         vm.assume(user != address(srTranche));
         vm.assume(user != address(jrTranche));
 
-        // Given interestWeights:
+        // Given: interestWeights:
         totalInterestWeight = uint16(bound(totalInterestWeight, 1, type(uint16).max));
         vm.prank(users.owner);
         pool.setInterestWeightTranche(0, totalInterestWeight);

--- a/test/fuzz/LendingPool/Repay.fuzz.t.sol
+++ b/test/fuzz/LendingPool/Repay.fuzz.t.sol
@@ -6,7 +6,6 @@ pragma solidity ^0.8.0;
 
 import { LendingPool_Fuzz_Test } from "./_LendingPool.fuzz.t.sol";
 
-import { AssetValuationLib } from "../../../lib/accounts-v2/src/libraries/AssetValuationLib.sol";
 import { DebtTokenErrors } from "../../../src/libraries/Errors.sol";
 import { GuardianErrors } from "../../../lib/accounts-v2/src/libraries/Errors.sol";
 import { LendingPool } from "../../../src/LendingPool.sol";

--- a/test/fuzz/LendingPool/Repay.fuzz.t.sol
+++ b/test/fuzz/LendingPool/Repay.fuzz.t.sol
@@ -31,11 +31,10 @@ contract Repay_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         public
     {
         // Given: collateralValue is smaller than maxExposure.
-        amountLoaned = uint112(bound(amountLoaned, 0, type(uint112).max - 1));
+        amountLoaned = uint112(bound(amountLoaned, 2, type(uint112).max - 1));
 
-        vm.assume(amountLoaned > availableFunds);
-        vm.assume(amountLoaned <= type(uint256).max / AssetValuationLib.ONE_4); // No overflow Risk Module
-        vm.assume(availableFunds > 0);
+        // And: The sender has insufficient funds to repay the loan.
+        availableFunds = bound(availableFunds, 1, amountLoaned - 1);
         vm.assume(sender != address(0));
         vm.assume(sender != users.liquidityProvider);
         vm.assume(sender != users.accountOwner);
@@ -62,11 +61,10 @@ contract Repay_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
 
     function testFuzz_Revert_repay_Paused(uint112 amountLoaned, uint256 availableFunds, address sender) public {
         // Given: collateralValue is smaller than maxExposure.
-        amountLoaned = uint112(bound(amountLoaned, 0, type(uint112).max - 1));
+        amountLoaned = uint112(bound(amountLoaned, 2, type(uint112).max - 1));
 
-        vm.assume(amountLoaned > availableFunds);
-        vm.assume(amountLoaned <= type(uint256).max / AssetValuationLib.ONE_4); // No overflow Risk Module
-        vm.assume(availableFunds > 0);
+        // And: The sender has insufficient funds to repay the loan.
+        availableFunds = bound(availableFunds, 1, amountLoaned - 1);
         vm.assume(sender != address(0));
         vm.assume(sender != users.liquidityProvider);
         vm.assume(sender != users.accountOwner);
@@ -104,9 +102,12 @@ contract Repay_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         address nonAccount
     ) public {
         vm.assume(nonAccount != address(account));
-        vm.assume(availableFunds > amountRepaid);
         vm.assume(sender != users.liquidityProvider);
         vm.assume(sender != address(account));
+
+        // Given: The sender has sufficient funds.
+        availableFunds = uint128(bound(availableFunds, 1, type(uint128).max));
+        amountRepaid = bound(amountRepaid, 0, availableFunds - 1);
         vm.prank(users.liquidityProvider);
         // forge-lint: disable-next-line(erc20-unchecked-transfer)
         mockERC20.stable1.transfer(sender, availableFunds);
@@ -121,11 +122,10 @@ contract Repay_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         public
     {
         // Given: collateralValue is smaller than maxExposure.
-        amountLoaned = uint112(bound(amountLoaned, 0, type(uint112).max - 1));
+        amountLoaned = uint112(bound(amountLoaned, 2, type(uint112).max - 1));
 
-        vm.assume(amountLoaned > amountRepaid);
-        vm.assume(amountRepaid > 0);
-        vm.assume(amountLoaned <= type(uint256).max / AssetValuationLib.ONE_4); // No overflow Risk Module
+        // And: The repaid amount is smaller than the loan.
+        amountRepaid = bound(amountRepaid, 1, amountLoaned - 1);
         vm.assume(sender != address(0));
         vm.assume(sender != users.liquidityProvider);
         vm.assume(sender != users.accountOwner);
@@ -158,10 +158,7 @@ contract Repay_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
 
     function testFuzz_Success_Repay_ExactAmount(uint112 amountLoaned, address sender) public {
         // Given: collateralValue is smaller than maxExposure.
-        amountLoaned = uint112(bound(amountLoaned, 0, type(uint112).max - 1));
-
-        vm.assume(amountLoaned > 0);
-        vm.assume(amountLoaned <= type(uint256).max / AssetValuationLib.ONE_4); // No overflow Risk Module
+        amountLoaned = uint112(bound(amountLoaned, 1, type(uint112).max - 1));
         vm.assume(sender != address(0));
         vm.assume(sender != users.liquidityProvider);
         vm.assume(sender != users.accountOwner);
@@ -196,11 +193,9 @@ contract Repay_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         public
     {
         // Given: collateralValue is smaller than maxExposure.
-        amountLoaned = uint112(bound(amountLoaned, 0, type(uint112).max - 1));
+        amountLoaned = uint112(bound(amountLoaned, 1, type(uint112).max - 1));
 
-        vm.assume(availableFunds > amountLoaned);
-        vm.assume(amountLoaned > 0);
-        vm.assume(amountLoaned <= type(uint256).max / AssetValuationLib.ONE_4); // No overflow Risk Module
+        availableFunds = uint128(bound(availableFunds, uint256(amountLoaned) + 1, type(uint128).max));
         vm.assume(sender != address(0));
         vm.assume(sender != users.liquidityProvider);
         vm.assume(sender != users.accountOwner);

--- a/test/fuzz/LendingPool/SetLiquidationParameters.fuzz.t.sol
+++ b/test/fuzz/LendingPool/SetLiquidationParameters.fuzz.t.sol
@@ -63,7 +63,12 @@ contract SetLiquidationParameters_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test
         uint16 minRewardWeight,
         uint80 maxReward
     ) public {
-        vm.assume(uint32(initiationWeight) + penaltyWeight + terminationWeight > pool.getMaxTotalPenalty());
+        // Given: The sum of the weights exceeds the maximum total penalty.
+        uint256 maxTotalPenalty = pool.getMaxTotalPenalty();
+        uint256 minTerminationWeight = maxTotalPenalty + 1 > uint32(initiationWeight) + penaltyWeight
+            ? maxTotalPenalty + 1 - initiationWeight - penaltyWeight
+            : 0;
+        terminationWeight = uint16(bound(terminationWeight, minTerminationWeight, type(uint16).max));
 
         vm.startPrank(users.owner);
         vm.expectRevert(LendingPoolErrors.LiquidationWeightsTooHigh.selector);
@@ -78,7 +83,10 @@ contract SetLiquidationParameters_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test
         uint16 minRewardWeight,
         uint80 maxReward
     ) public {
-        vm.assume(uint32(initiationWeight) + penaltyWeight + terminationWeight <= pool.getMaxTotalPenalty());
+        initiationWeight = uint16(bound(initiationWeight, 0, pool.getMaxTotalPenalty()));
+        penaltyWeight = uint16(bound(penaltyWeight, 0, pool.getMaxTotalPenalty() - initiationWeight));
+        terminationWeight =
+            uint16(bound(terminationWeight, 0, pool.getMaxTotalPenalty() - initiationWeight - penaltyWeight));
 
         minRewardWeight = uint16(bound(minRewardWeight, 5000 + 1, type(uint16).max));
 
@@ -95,7 +103,10 @@ contract SetLiquidationParameters_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test
         uint16 minRewardWeight,
         uint80 maxReward
     ) public {
-        vm.assume(uint32(initiationWeight) + penaltyWeight + terminationWeight <= pool.getMaxTotalPenalty());
+        initiationWeight = uint16(bound(initiationWeight, 0, pool.getMaxTotalPenalty()));
+        penaltyWeight = uint16(bound(penaltyWeight, 0, pool.getMaxTotalPenalty() - initiationWeight));
+        terminationWeight =
+            uint16(bound(terminationWeight, 0, pool.getMaxTotalPenalty() - initiationWeight - penaltyWeight));
 
         minRewardWeight = uint16(bound(minRewardWeight, 0, 5000));
 

--- a/test/fuzz/LendingPool/SettleLiquidationHappy.fuzz.t.sol
+++ b/test/fuzz/LendingPool/SettleLiquidationHappy.fuzz.t.sol
@@ -11,6 +11,7 @@ import { stdStorage, StdStorage } from "../../../lib/accounts-v2/lib/forge-std/s
 /**
  * @notice Fuzz tests for the function "settleLiquidationHappyFlow" of contract "LendingPool".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract SettleLiquidationHappy_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////
@@ -46,16 +47,13 @@ contract SettleLiquidationHappy_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         address auctionTerminator,
         uint128 surplus
     ) public {
-        // forge-lint: disable-next-item(unsafe-typecast)
-        surplus = uint128(bound(surplus, 1, type(uint128).max));
-        vm.assume(startDebt > 0);
+        startDebt = uint128(bound(startDebt, 1, type(uint128).max));
         (uint256 initiationReward, uint256 auctionTerminationReward, uint256 liquidationPenalty) =
             pool.getCalculateRewards(startDebt, 0);
-        vm.assume(uint256(liquidity) >= startDebt + initiationReward + auctionTerminationReward + liquidationPenalty);
-        vm.assume(
-            uint256(liquidity) + surplus + initiationReward + auctionTerminationReward + liquidationPenalty
-                <= type(uint128).max
-        );
+        uint256 rewards = initiationReward + auctionTerminationReward + liquidationPenalty;
+        vm.assume(uint256(startDebt) + 2 * rewards < type(uint128).max);
+        surplus = uint128(bound(surplus, 1, type(uint128).max - startDebt - 2 * rewards));
+        liquidity = uint128(bound(liquidity, startDebt + rewards, type(uint128).max - surplus - rewards));
 
         vm.assume(
             auctionTerminator != address(srTranche) && auctionTerminator != address(jrTranche)

--- a/test/fuzz/LendingPool/SettleLiquidationUnhappy.fuzz.t.sol
+++ b/test/fuzz/LendingPool/SettleLiquidationUnhappy.fuzz.t.sol
@@ -50,10 +50,11 @@ contract SettleLiquidationUnhappy_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test
         address auctionTerminator
     ) public {
         // Given: There is liquidity and bad debt
-        vm.assume(liquidityJunior > 100);
-        vm.assume(liquiditySenior > 100);
+        liquidityJunior = uint128(bound(liquidityJunior, 100 + 1, type(uint128).max / 2 - 2));
+        liquiditySenior = uint128(bound(liquiditySenior, 100 + 1, type(uint128).max / 2 - 2));
         uint256 totalAmount = uint256(liquiditySenior) + uint256(liquidityJunior);
-        vm.assume(startDebt > totalAmount + 2); // Bad debt should be excess since initiator and terminator rewards are 1 and 1 respectively, it should be added to make the baddebt excess
+        // Bad debt should be excess since initiator and terminator rewards are 1 and 1 respectively, it should be added to make the baddebt excess
+        startDebt = uint128(bound(startDebt, totalAmount + 3, type(uint128).max));
         (uint256 initiationReward, uint256 terminationReward, uint256 liquidationPenalty) =
             pool.getCalculateRewards(startDebt, 0);
         uint256 openDebt = startDebt + initiationReward + terminationReward + liquidationPenalty;
@@ -92,12 +93,9 @@ contract SettleLiquidationUnhappy_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test
             pool.getCalculateRewards(startDebt, 0);
 
         // Given: Liquidity is deposited in Lending Pool
-        vm.assume(
-            uint256(liquidity) >= uint256(startDebt) + initiationReward + auctionTerminationReward + liquidationPenalty
-        );
-        vm.assume(
-            uint256(liquidity) + initiationReward + auctionTerminationReward + liquidationPenalty <= type(uint128).max
-        );
+        uint256 rewards = initiationReward + auctionTerminationReward + liquidationPenalty;
+        vm.assume(uint256(startDebt) + 2 * rewards <= type(uint128).max);
+        liquidity = uint128(bound(liquidity, uint256(startDebt) + rewards, type(uint128).max - rewards));
 
         //
         vm.assume(
@@ -184,12 +182,9 @@ contract SettleLiquidationUnhappy_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test
             pool.getCalculateRewards(startDebt, 0);
 
         // Given: Liquidity is deposited in Lending Pool
-        vm.assume(
-            uint256(liquidity) >= uint256(startDebt) + initiationReward + auctionTerminationReward + liquidationPenalty
-        );
-        vm.assume(
-            uint256(liquidity) + initiationReward + auctionTerminationReward + liquidationPenalty <= type(uint128).max
-        );
+        uint256 rewards = initiationReward + auctionTerminationReward + liquidationPenalty;
+        vm.assume(uint256(startDebt) + 2 * rewards <= type(uint128).max);
+        liquidity = uint128(bound(liquidity, uint256(startDebt) + rewards, type(uint128).max - rewards));
 
         //
         vm.assume(
@@ -267,12 +262,9 @@ contract SettleLiquidationUnhappy_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test
             pool.getCalculateRewards(startDebt, 0);
 
         // Given: Liquidity is deposited in Lending Pool
-        vm.assume(
-            uint256(liquidity) >= uint256(startDebt) + initiationReward + auctionTerminationReward + liquidationPenalty
-        );
-        vm.assume(
-            uint256(liquidity) + initiationReward + auctionTerminationReward + liquidationPenalty <= type(uint112).max
-        );
+        uint256 rewards = initiationReward + auctionTerminationReward + liquidationPenalty;
+        vm.assume(uint256(startDebt) + 2 * rewards <= type(uint112).max);
+        liquidity = uint112(bound(liquidity, uint256(startDebt) + rewards, type(uint112).max - rewards));
 
         // There is still open debt
         vm.assume(auctionTerminationReward > 1);

--- a/test/fuzz/LendingPool/Skim.fuzz.t.sol
+++ b/test/fuzz/LendingPool/Skim.fuzz.t.sol
@@ -11,6 +11,7 @@ import { LendingPoolErrors } from "../../../src/libraries/Errors.sol";
 /**
  * @notice Fuzz tests for the function "skim" of contract "LendingPool".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract Skim_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -24,7 +25,7 @@ contract Skim_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
                               TESTS
     //////////////////////////////////////////////////////////////*/
     function testFuzz_Revert_skim_OngoingAuctions(uint16 auctionsInProgress_, address sender) public {
-        vm.assume(auctionsInProgress_ > 0);
+        auctionsInProgress_ = uint16(bound(auctionsInProgress_, 1, type(uint16).max));
         pool.setAuctionsInProgress(auctionsInProgress_);
 
         vm.startPrank(sender);
@@ -36,8 +37,8 @@ contract Skim_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     function testFuzz_Success_skim(uint128 balanceOf, uint128 totalDebt, uint128 totalLiquidity, address sender)
         public
     {
-        vm.assume(uint256(balanceOf) + totalDebt <= type(uint128).max);
-        vm.assume(totalLiquidity <= balanceOf + totalDebt);
+        totalDebt = uint128(bound(totalDebt, 0, type(uint128).max - balanceOf));
+        totalLiquidity = uint128(bound(totalLiquidity, 0, balanceOf + totalDebt));
 
         pool.setTotalRealisedLiquidity(totalLiquidity);
         pool.setRealisedDebt(totalDebt);

--- a/test/fuzz/LendingPool/StartLiquidation.fuzz.t.sol
+++ b/test/fuzz/LendingPool/StartLiquidation.fuzz.t.sol
@@ -14,7 +14,7 @@ import { LendingPoolErrors } from "../../../src/libraries/Errors.sol";
 /**
  * @notice Fuzz tests for the function "startLiquidation" of contract "LendingPool".
  */
-// forge-lint: disable-next-item(divide-before-multiply)
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract StartLiquidation_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     using FixedPointMathLib for uint256;
     /* ///////////////////////////////////////////////////////////////
@@ -52,8 +52,7 @@ contract StartLiquidation_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     function testFuzz_Revert_StartLiquidation_Paused(uint112 amountLoaned, address liquidationInitiator) public {
         // Given: Account has debt
         bytes3 emptyBytes4;
-        vm.assume(amountLoaned > 1);
-        vm.assume(amountLoaned <= (type(uint112).max / 300) * 100); // No overflow when debt is increased
+        amountLoaned = uint112(bound(amountLoaned, 1 + 1, (type(uint112).max / 300) * 100)); // No overflow when debt is increased
         depositErc20InAccount(account, mockERC20.stable1, amountLoaned);
         vm.prank(users.liquidityProvider);
         mockERC20.stable1.approve(address(pool), type(uint256).max);
@@ -83,9 +82,10 @@ contract StartLiquidation_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     ) public {
         // Given: Account has debt
         bytes3 emptyBytes4;
-        vm.assume(amountLoaned > 1);
-        vm.assume(amountLoaned <= (type(uint112).max / 300) * 100); // No overflow when debt is increased
-        vm.assume(uint32(initiationWeight) + penaltyWeight + terminationWeight <= 1100);
+        amountLoaned = uint112(bound(amountLoaned, 1 + 1, (type(uint112).max / 300) * 100)); // No overflow when debt is increased
+        initiationWeight = uint16(bound(initiationWeight, 0, 1100));
+        penaltyWeight = uint16(bound(penaltyWeight, 0, 1100 - initiationWeight));
+        terminationWeight = uint16(bound(terminationWeight, 0, 1100 - initiationWeight - penaltyWeight));
         depositErc20InAccount(account, mockERC20.stable1, amountLoaned);
         vm.prank(users.liquidityProvider);
         mockERC20.stable1.approve(address(pool), type(uint256).max);
@@ -143,9 +143,10 @@ contract StartLiquidation_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     ) public {
         // Given: Account has debt
         bytes3 emptyBytes4;
-        vm.assume(amountLoaned > 1);
-        vm.assume(amountLoaned <= (type(uint112).max / 300) * 100); // No overflow when debt is increased
-        vm.assume(uint32(initiationWeight) + penaltyWeight + terminationWeight <= 1100);
+        amountLoaned = uint112(bound(amountLoaned, 1 + 1, (type(uint112).max / 300) * 100)); // No overflow when debt is increased
+        initiationWeight = uint16(bound(initiationWeight, 0, 1100));
+        penaltyWeight = uint16(bound(penaltyWeight, 0, 1100 - initiationWeight));
+        terminationWeight = uint16(bound(terminationWeight, 0, 1100 - initiationWeight - penaltyWeight));
         depositErc20InAccount(account, mockERC20.stable1, amountLoaned);
         vm.prank(users.liquidityProvider);
         mockERC20.stable1.approve(address(pool), type(uint256).max);
@@ -213,9 +214,10 @@ contract StartLiquidation_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     ) public {
         // Given: Account has debt
         bytes3 emptyBytes4;
-        vm.assume(amountLoaned > 1);
-        vm.assume(amountLoaned <= (type(uint112).max / 150) * 100); // No overflow when debt is increased
-        vm.assume(uint32(initiationWeight) + penaltyWeight + terminationWeight <= 1100);
+        amountLoaned = uint112(bound(amountLoaned, 1 + 1, (type(uint112).max / 150) * 100)); // No overflow when debt is increased
+        initiationWeight = uint16(bound(initiationWeight, 0, 1100));
+        penaltyWeight = uint16(bound(penaltyWeight, 0, 1100 - initiationWeight));
+        terminationWeight = uint16(bound(terminationWeight, 0, 1100 - initiationWeight - penaltyWeight));
         depositErc20InAccount(account, mockERC20.stable1, amountLoaned);
         vm.prank(users.liquidityProvider);
         mockERC20.stable1.approve(address(pool), type(uint256).max);
@@ -232,8 +234,7 @@ contract StartLiquidation_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         debt.setRealisedDebt(uint256(amountLoaned + 1));
 
         //And: an auction is ongoing
-        vm.assume(auctionsInProgress > 0);
-        vm.assume(auctionsInProgress < type(uint16).max);
+        auctionsInProgress = uint16(bound(auctionsInProgress, 1, type(uint16).max - 1));
         pool.setAuctionsInProgress(auctionsInProgress);
         vm.prank(address(pool));
         jrTranche.setAuctionInProgress(true);

--- a/test/fuzz/LendingPool/SyncInterests.fuzz.t.sol
+++ b/test/fuzz/LendingPool/SyncInterests.fuzz.t.sol
@@ -11,6 +11,7 @@ import { AssetValuationLib } from "../../../lib/accounts-v2/src/libraries/AssetV
 /**
  * @notice Fuzz tests for the function "syncInterests" of contract "LendingPool".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract SyncInterests_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -29,16 +30,13 @@ contract SyncInterests_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         uint120 realisedLiquidity,
         uint80 interestRate
     ) public {
-        vm.assume(realisedDebt <= type(uint256).max / AssetValuationLib.ONE_4); // No overflow Risk Module
+        // Highest possible debt at 1000% over 5 years: 3402823669209384912995114146594816.
+        realisedDebt = uint128(bound(realisedDebt, 1, type(uint128).max / (10 ** 5)));
         // Given: deltaTimestamp than 5 years, realisedDebt than 3402823669209384912995114146594816 and bigger than 0
-        vm.assume(deltaTimestamp <= 5 * 365 * 24 * 60 * 60);
         //5 year
-        vm.assume(interestRate <= 10 * 10 ** 18);
+        interestRate = uint80(bound(interestRate, 0, 10 * 10 ** 18));
         //1000%
-        vm.assume(realisedDebt <= type(uint128).max / (10 ** 5));
-        //highest possible debt at 1000% over 5 years: 3402823669209384912995114146594816
-        vm.assume(realisedDebt > 0);
-        vm.assume(realisedDebt <= realisedLiquidity);
+        realisedLiquidity = uint120(bound(realisedLiquidity, realisedDebt, type(uint120).max));
 
         // And: the users.accountOwner takes realisedDebt debt
         depositErc20InAccount(account, mockERC20.stable1, realisedDebt);

--- a/test/fuzz/LendingPool/SyncInterests.fuzz.t.sol
+++ b/test/fuzz/LendingPool/SyncInterests.fuzz.t.sol
@@ -6,8 +6,6 @@ pragma solidity ^0.8.0;
 
 import { LendingPool_Fuzz_Test } from "./_LendingPool.fuzz.t.sol";
 
-import { AssetValuationLib } from "../../../lib/accounts-v2/src/libraries/AssetValuationLib.sol";
-
 /**
  * @notice Fuzz tests for the function "syncInterests" of contract "LendingPool".
  */

--- a/test/fuzz/LendingPool/TotalAssets.fuzz.t.sol
+++ b/test/fuzz/LendingPool/TotalAssets.fuzz.t.sol
@@ -9,6 +9,7 @@ import { LendingPool_Fuzz_Test } from "./_LendingPool.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "totalAssets" of contract "LendingPool".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract TotalAssets_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -25,9 +26,7 @@ contract TotalAssets_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         // Given: collateralValue is smaller than maxExposure.
         // forge-lint: disable-next-item(unsafe-typecast)
         realisedDebt = uint112(bound(realisedDebt, 1, type(uint112).max - 1));
-        vm.assume(interestRate <= 1e3 * 1e18); // 1000%.
-        vm.assume(interestRate > 0);
-        vm.assume(deltaTimestamp <= 5 * 365 * 24 * 60 * 60); // 5 year.
+        interestRate = uint80(bound(interestRate, 0 + 1, 1e3 * 1e18));
 
         vm.prank(address(srTranche));
         pool.depositInLendingPool(type(uint128).max, users.liquidityProvider);

--- a/test/fuzz/LendingPool/TotalLiquidity.fuzz.t.sol
+++ b/test/fuzz/LendingPool/TotalLiquidity.fuzz.t.sol
@@ -9,6 +9,7 @@ import { LendingPool_Fuzz_Test } from "./_LendingPool.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "totalLiquidity" of contract "LendingPool".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract TotalLiquidity_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -30,10 +31,8 @@ contract TotalLiquidity_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         // Given: collateralValue is smaller than maxExposure.
         // forge-lint: disable-next-item(unsafe-typecast)
         realisedDebt = uint112(bound(realisedDebt, 1, type(uint112).max - 1));
-        vm.assume(deltaTimestamp <= 5 * 365 * 24 * 60 * 60); // 5 year
-        vm.assume(interestRate <= 1e3 * 10 ** 18); // 1000%
-        vm.assume(interestRate > 0);
-        vm.assume(initialLiquidity >= realisedDebt);
+        interestRate = uint80(bound(interestRate, 0 + 1, 1e3 * 10 ** 18));
+        initialLiquidity = uint120(bound(initialLiquidity, realisedDebt, type(uint120).max));
 
         vm.prank(address(srTranche));
         pool.depositInLendingPool(initialLiquidity, users.liquidityProvider);

--- a/test/fuzz/LendingPool/UpdateInterestRate.fuzz.t.sol
+++ b/test/fuzz/LendingPool/UpdateInterestRate.fuzz.t.sol
@@ -32,15 +32,14 @@ contract UpdateInterestRate_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
         uint80 interestRate
     ) public {
         // realisedDebt smaller than equal to than 3402823669209384912995114146594816
-        //5 year
-        vm.assume(deltaTimestamp <= 5 * 365 * 24 * 60 * 60);
         //1000%
-        vm.assume(interestRate <= 10 * 10 ** 18);
-        //highest possible debt at 1000% over 5 years: 3402823669209384912995114146594816
-        vm.assume(realisedDebt <= type(uint128).max / (10 ** 5));
+        interestRate = uint80(bound(interestRate, 0, 10 * 10 ** 18));
+
+        // Highest possible debt at 1000% over 5 years: 3402823669209384912995114146594816.
+        realisedDebt = uint128(bound(realisedDebt, 0, type(uint128).max / (10 ** 5)));
 
         // Given: Utilisation below 100% (test-case).
-        vm.assume(realisedDebt <= realisedLiquidity);
+        realisedLiquidity = uint120(bound(realisedLiquidity, realisedDebt, type(uint120).max));
 
         pool.setTotalRealisedLiquidity(realisedLiquidity);
         pool.setRealisedDebt(realisedDebt);
@@ -75,8 +74,15 @@ contract UpdateInterestRate_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
 
         // And: Utilisation is below 100% (test-case).
         // And: utilisation does not overflow.
-        realisedDebt_ = uint128(bound(realisedDebt_, 0, type(uint128).max / ONE_4));
-        realisedDebt_ = uint128(bound(realisedDebt_, 0, totalRealisedLiquidity_));
+        realisedDebt_ = uint128(
+            bound(
+                realisedDebt_,
+                0,
+                totalRealisedLiquidity_ < type(uint128).max / ONE_4
+                    ? totalRealisedLiquidity_
+                    : type(uint128).max / ONE_4
+            )
+        );
 
         // And: The InterestConfiguration is set.
         vm.prank(users.owner);
@@ -158,8 +164,8 @@ contract UpdateInterestRate_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     ) public {
         // Given: totalRealisedLiquidity_ is equal to 0, baseRate_ is less than 100000, highSlope_ is bigger than lowSlope_
         uint256 totalRealisedLiquidity_ = 0;
-        vm.assume(realisedDebt_ <= type(uint128).max / ONE_4); //highest possible debt at 1000% over 5 years: 3402823669209384912995114146594816
-        vm.assume(utilisationThreshold_ <= ONE_4);
+        realisedDebt_ = bound(realisedDebt_, 0, type(uint128).max / ONE_4);
+        utilisationThreshold_ = uint16(bound(utilisationThreshold_, 0, ONE_4));
 
         // When: The InterestConfiguration is set
         vm.prank(users.owner);

--- a/test/fuzz/LendingPool/WithdrawFromLendingPool.fuzz.t.sol
+++ b/test/fuzz/LendingPool/WithdrawFromLendingPool.fuzz.t.sol
@@ -12,6 +12,7 @@ import { LendingPoolErrors } from "../../../src/libraries/Errors.sol";
 /**
  * @notice Fuzz tests for the function "withdrawFromLendingPool" of contract "LendingPool".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract WithdrawFromLendingPool_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -30,7 +31,7 @@ contract WithdrawFromLendingPool_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test 
         address unprivilegedAddress
     ) public {
         vm.assume(unprivilegedAddress != address(srTranche));
-        vm.assume(assetsWithdrawn > 0);
+        assetsWithdrawn = uint128(bound(assetsWithdrawn, 1, type(uint128).max));
 
         vm.prank(address(srTranche));
         pool.depositInLendingPool(assetsWithdrawn, users.liquidityProvider);
@@ -46,7 +47,8 @@ contract WithdrawFromLendingPool_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test 
         uint128 assetsWithdrawn,
         address receiver
     ) public {
-        vm.assume(assetsDeposited < assetsWithdrawn);
+        assetsWithdrawn = uint128(bound(assetsWithdrawn, 1, type(uint128).max));
+        assetsDeposited = uint128(bound(assetsDeposited, 0, assetsWithdrawn - 1));
 
         vm.startPrank(address(srTranche));
         pool.depositInLendingPool(assetsDeposited, users.liquidityProvider);
@@ -63,7 +65,7 @@ contract WithdrawFromLendingPool_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test 
     ) public {
         vm.assume(receiver != address(pool));
         vm.assume(receiver != users.liquidityProvider);
-        vm.assume(assetsDeposited >= assetsWithdrawn);
+        assetsDeposited = uint128(bound(assetsDeposited, assetsWithdrawn, type(uint128).max));
 
         vm.prank(address(srTranche));
         pool.depositInLendingPool(assetsDeposited, users.liquidityProvider);
@@ -84,7 +86,7 @@ contract WithdrawFromLendingPool_LendingPool_Fuzz_Test is LendingPool_Fuzz_Test 
     ) public {
         vm.assume(receiver != address(pool));
         vm.assume(receiver != users.liquidityProvider);
-        vm.assume(assetsDeposited >= assetsWithdrawn);
+        assetsDeposited = uint128(bound(assetsDeposited, assetsWithdrawn, type(uint128).max));
 
         vm.startPrank(address(srTranche));
         pool.depositInLendingPool(assetsDeposited, users.liquidityProvider);

--- a/test/fuzz/Tranche/Deposit.fuzz.t.sol
+++ b/test/fuzz/Tranche/Deposit.fuzz.t.sol
@@ -11,6 +11,7 @@ import { TrancheErrors } from "../../../src/libraries/Errors.sol";
 /**
  * @notice Fuzz tests for the function "deposit" of contract "Tranche".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract Deposit_Tranche_Fuzz_Test is Tranche_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -51,7 +52,7 @@ contract Deposit_Tranche_Fuzz_Test is Tranche_Fuzz_Test {
     }
 
     function testFuzz_Success_deposit(uint128 assets, address receiver) public {
-        vm.assume(assets > 0);
+        assets = uint128(bound(assets, 1, type(uint128).max));
 
         vm.prank(users.liquidityProvider);
         tranche.deposit(assets, receiver);
@@ -63,7 +64,7 @@ contract Deposit_Tranche_Fuzz_Test is Tranche_Fuzz_Test {
     }
 
     function testFuzz_Success_deposit_sync(uint128 assets, address receiver) public {
-        vm.assume(assets > 3);
+        assets = uint128(bound(assets, 3 + 1, type(uint128).max));
 
         vm.prank(users.liquidityProvider);
         tranche.deposit(assets / 3, receiver);

--- a/test/fuzz/Tranche/MaxMint.fuzz.t.sol
+++ b/test/fuzz/Tranche/MaxMint.fuzz.t.sol
@@ -11,6 +11,7 @@ import { stdStorage, StdStorage } from "../../../lib/accounts-v2/lib/forge-std/s
 /**
  * @notice Fuzz tests for the function "maxMint" of contract "Tranche".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract MaxMint_Tranche_Fuzz_Test is Tranche_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////
@@ -46,8 +47,8 @@ contract MaxMint_Tranche_Fuzz_Test is Tranche_Fuzz_Test {
         uint128 totalLiquidity,
         uint128 liquidityOf
     ) public {
-        vm.assume(liquidityOf > 0);
-        vm.assume(liquidityOf <= totalLiquidity);
+        liquidityOf = uint128(bound(liquidityOf, 1, type(uint128).max));
+        totalLiquidity = uint128(bound(totalLiquidity, liquidityOf, type(uint128).max));
 
         vm.prank(users.owner);
         pool.setTotalRealisedLiquidity(totalLiquidity);
@@ -65,9 +66,9 @@ contract MaxMint_Tranche_Fuzz_Test is Tranche_Fuzz_Test {
         uint128 liquidityOf,
         uint128 totalShares
     ) public {
-        vm.assume(liquidityOf > 0);
-        vm.assume(totalShares > 0);
-        vm.assume(liquidityOf <= totalLiquidity);
+        liquidityOf = uint128(bound(liquidityOf, 1, type(uint128).max));
+        totalShares = uint128(bound(totalShares, 1, type(uint128).max));
+        totalLiquidity = uint128(bound(totalLiquidity, liquidityOf, type(uint128).max));
 
         vm.prank(users.owner);
         pool.setTotalRealisedLiquidity(totalLiquidity);

--- a/test/fuzz/Tranche/MaxRedeem.fuzz.t.sol
+++ b/test/fuzz/Tranche/MaxRedeem.fuzz.t.sol
@@ -11,6 +11,7 @@ import { stdStorage, StdStorage } from "../../../lib/accounts-v2/lib/forge-std/s
 /**
  * @notice Fuzz tests for the function "maxRedeem" of contract "Tranche".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract MaxRedeem_Tranche_Fuzz_Test is Tranche_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////
@@ -56,10 +57,13 @@ contract MaxRedeem_Tranche_Fuzz_Test is Tranche_Fuzz_Test {
         uint128 claimableLiquidityOfTranche,
         uint128 availableLiquidityOfTranche
     ) public {
-        vm.assume(shares <= totalShares);
-        vm.assume(claimableLiquidityOfTranche <= totalLiquidity);
-        vm.assume(availableLiquidityOfTranche <= totalLiquidity);
-        if (totalShares > 0) vm.assume(claimableLiquidityOfTranche > 0);
+        if (totalShares > 0) {
+            totalLiquidity = uint128(bound(totalLiquidity, 1, type(uint128).max));
+        }
+        shares = uint128(bound(shares, 0, totalShares));
+        claimableLiquidityOfTranche =
+            uint128(bound(claimableLiquidityOfTranche, totalShares > 0 ? 1 : 0, totalLiquidity));
+        availableLiquidityOfTranche = uint128(bound(availableLiquidityOfTranche, 0, totalLiquidity));
 
         stdstore.target(address(tranche)).sig(pool.balanceOf.selector).with_key(owner).checked_write(shares);
         stdstore.target(address(tranche)).sig(pool.totalSupply.selector).checked_write(totalShares);
@@ -89,10 +93,13 @@ contract MaxRedeem_Tranche_Fuzz_Test is Tranche_Fuzz_Test {
         uint128 claimableLiquidityOfTranche,
         uint128 availableLiquidityOfTranche
     ) public {
-        vm.assume(shares <= totalShares);
-        vm.assume(claimableLiquidityOfTranche <= totalLiquidity);
-        vm.assume(availableLiquidityOfTranche <= totalLiquidity);
-        if (totalShares > 0) vm.assume(claimableLiquidityOfTranche > 0);
+        if (totalShares > 0) {
+            totalLiquidity = uint128(bound(totalLiquidity, 1, type(uint128).max));
+        }
+        shares = uint128(bound(shares, 0, totalShares));
+        claimableLiquidityOfTranche =
+            uint128(bound(claimableLiquidityOfTranche, totalShares > 0 ? 1 : 0, totalLiquidity));
+        availableLiquidityOfTranche = uint128(bound(availableLiquidityOfTranche, 0, totalLiquidity));
 
         stdstore.target(address(tranche)).sig(pool.balanceOf.selector).with_key(owner).checked_write(shares);
         stdstore.target(address(tranche)).sig(pool.totalSupply.selector).checked_write(totalShares);

--- a/test/fuzz/Tranche/MaxWithdraw.fuzz.t.sol
+++ b/test/fuzz/Tranche/MaxWithdraw.fuzz.t.sol
@@ -11,6 +11,7 @@ import { stdStorage, StdStorage } from "../../../lib/accounts-v2/lib/forge-std/s
 /**
  * @notice Fuzz tests for the function "maxWithdraw" of contract "Tranche".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract MaxWithdraw_Tranche_Fuzz_Test is Tranche_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////
@@ -56,9 +57,18 @@ contract MaxWithdraw_Tranche_Fuzz_Test is Tranche_Fuzz_Test {
         uint128 claimableLiquidityOfTranche,
         uint128 availableLiquidityOfTranche
     ) public {
-        vm.assume(shares <= totalShares);
-        vm.assume(claimableLiquidityOfTranche <= totalLiquidity);
-        vm.assume(availableLiquidityOfTranche <= totalLiquidity);
+        shares = uint128(bound(shares, 0, totalShares));
+        claimableLiquidityOfTranche = uint128(bound(claimableLiquidityOfTranche, 0, totalLiquidity));
+
+        uint256 claimableAssets;
+        if (shares == 0) {
+            claimableAssets = 0;
+        } else {
+            claimableAssets = uint256(shares) * claimableLiquidityOfTranche / totalShares;
+        }
+
+        // And: The tranche holds enough underlying assets.
+        availableLiquidityOfTranche = uint128(bound(availableLiquidityOfTranche, claimableAssets, totalLiquidity));
 
         stdstore.target(address(tranche)).sig(pool.balanceOf.selector).with_key(owner).checked_write(shares);
         stdstore.target(address(tranche)).sig(pool.totalSupply.selector).checked_write(totalShares);
@@ -68,14 +78,6 @@ contract MaxWithdraw_Tranche_Fuzz_Test is Tranche_Fuzz_Test {
             .sig(pool.balanceOf.selector)
             .with_key(address(pool))
             .checked_write(availableLiquidityOfTranche);
-
-        uint256 claimableAssets;
-        if (shares == 0) {
-            claimableAssets = 0;
-        } else {
-            claimableAssets = uint256(shares) * claimableLiquidityOfTranche / totalShares;
-        }
-        vm.assume(availableLiquidityOfTranche >= claimableAssets);
 
         assertEq(tranche.maxWithdraw(owner), claimableAssets);
     }
@@ -88,9 +90,18 @@ contract MaxWithdraw_Tranche_Fuzz_Test is Tranche_Fuzz_Test {
         uint128 claimableLiquidityOfTranche,
         uint128 availableLiquidityOfTranche
     ) public {
-        vm.assume(shares <= totalShares);
-        vm.assume(claimableLiquidityOfTranche <= totalLiquidity);
-        vm.assume(availableLiquidityOfTranche <= totalLiquidity);
+        shares = uint128(bound(shares, 0, totalShares));
+        claimableLiquidityOfTranche = uint128(bound(claimableLiquidityOfTranche, 0, totalLiquidity));
+
+        uint256 claimableAssets;
+        if (shares == 0) {
+            claimableAssets = 0;
+        } else {
+            claimableAssets = uint256(shares) * claimableLiquidityOfTranche / totalShares;
+        }
+
+        // And: The underlying assets are the limiting factor.
+        availableLiquidityOfTranche = uint128(bound(availableLiquidityOfTranche, 0, claimableAssets));
 
         stdstore.target(address(tranche)).sig(pool.balanceOf.selector).with_key(owner).checked_write(shares);
         stdstore.target(address(tranche)).sig(pool.totalSupply.selector).checked_write(totalShares);
@@ -100,14 +111,6 @@ contract MaxWithdraw_Tranche_Fuzz_Test is Tranche_Fuzz_Test {
             .sig(pool.balanceOf.selector)
             .with_key(address(pool))
             .checked_write(availableLiquidityOfTranche);
-
-        uint256 claimableAssets;
-        if (shares == 0) {
-            claimableAssets = 0;
-        } else {
-            claimableAssets = uint256(shares) * claimableLiquidityOfTranche / totalShares;
-        }
-        vm.assume(availableLiquidityOfTranche <= claimableAssets);
 
         assertEq(tranche.maxWithdraw(owner), availableLiquidityOfTranche);
     }

--- a/test/fuzz/Tranche/Mint.fuzz.t.sol
+++ b/test/fuzz/Tranche/Mint.fuzz.t.sol
@@ -11,6 +11,7 @@ import { TrancheErrors } from "../../../src/libraries/Errors.sol";
 /**
  * @notice Fuzz tests for the function "mint" of contract "Tranche".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract Mint_Tranche_Fuzz_Test is Tranche_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -34,7 +35,7 @@ contract Mint_Tranche_Fuzz_Test is Tranche_Fuzz_Test {
     }
 
     function testFuzz_Success_mint(uint128 shares, address receiver) public {
-        vm.assume(shares > 0);
+        shares = uint128(bound(shares, 1, type(uint128).max));
 
         vm.prank(users.liquidityProvider);
         tranche.mint(shares, receiver);

--- a/test/fuzz/Tranche/Redeem.fuzz.t.sol
+++ b/test/fuzz/Tranche/Redeem.fuzz.t.sol
@@ -12,6 +12,7 @@ import { TrancheErrors } from "../../../src/libraries/Errors.sol";
 /**
  * @notice Fuzz tests for the function "redeem" of contract "Tranche".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract Redeem_Tranche_Fuzz_Test is Tranche_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -48,7 +49,7 @@ contract Redeem_Tranche_Fuzz_Test is Tranche_Fuzz_Test {
         address unprivilegedAddress
     ) public {
         vm.assume(unprivilegedAddress != owner);
-        vm.assume(shares > 0);
+        shares = uint128(bound(shares, 1, type(uint128).max));
 
         vm.prank(users.liquidityProvider);
         tranche.mint(shares, owner);
@@ -67,8 +68,8 @@ contract Redeem_Tranche_Fuzz_Test is Tranche_Fuzz_Test {
         address beneficiary
     ) public {
         vm.assume(beneficiary != owner);
-        vm.assume(sharesMinted > 0);
-        vm.assume(sharesMinted < sharesAllowed);
+        sharesMinted = uint128(bound(sharesMinted, 1, type(uint128).max - 1));
+        sharesAllowed = uint128(bound(sharesAllowed, uint256(sharesMinted) + 1, type(uint128).max));
 
         vm.prank(users.liquidityProvider);
         tranche.mint(sharesMinted, owner);
@@ -88,8 +89,8 @@ contract Redeem_Tranche_Fuzz_Test is Tranche_Fuzz_Test {
         address owner,
         address receiver
     ) public {
-        vm.assume(sharesMinted > 0);
-        vm.assume(sharesMinted < sharesRedeemed);
+        sharesMinted = uint128(bound(sharesMinted, 1, type(uint128).max - 1));
+        sharesRedeemed = uint128(bound(sharesRedeemed, uint256(sharesMinted) + 1, type(uint128).max));
 
         vm.prank(users.liquidityProvider);
         tranche.mint(sharesMinted, owner);
@@ -106,9 +107,8 @@ contract Redeem_Tranche_Fuzz_Test is Tranche_Fuzz_Test {
         address owner,
         address receiver
     ) public {
-        vm.assume(sharesMinted > 0);
-        vm.assume(sharesRedeemed > 0);
-        vm.assume(sharesMinted >= sharesRedeemed);
+        sharesMinted = uint128(bound(sharesMinted, 1, type(uint128).max));
+        sharesRedeemed = uint128(bound(sharesRedeemed, 1, sharesMinted));
         vm.assume(receiver != users.liquidityProvider);
         vm.assume(receiver != address(pool));
 
@@ -133,10 +133,9 @@ contract Redeem_Tranche_Fuzz_Test is Tranche_Fuzz_Test {
         address owner,
         address beneficiary
     ) public {
-        vm.assume(sharesMinted > 0);
-        vm.assume(sharesRedeemed > 0);
-        vm.assume(sharesMinted >= sharesRedeemed);
-        vm.assume(sharesAllowed >= sharesRedeemed);
+        sharesMinted = uint128(bound(sharesMinted, 1, type(uint128).max));
+        sharesRedeemed = uint128(bound(sharesRedeemed, 1, sharesMinted));
+        sharesAllowed = uint128(bound(sharesAllowed, sharesRedeemed, type(uint128).max));
         vm.assume(receiver != users.liquidityProvider);
         vm.assume(receiver != address(pool));
         vm.assume(beneficiary != owner);
@@ -165,9 +164,8 @@ contract Redeem_Tranche_Fuzz_Test is Tranche_Fuzz_Test {
         address owner,
         address beneficiary
     ) public {
-        vm.assume(sharesMinted > 0);
-        vm.assume(sharesRedeemed > 0);
-        vm.assume(sharesMinted >= sharesRedeemed);
+        sharesMinted = uint128(bound(sharesMinted, 1, type(uint128).max));
+        sharesRedeemed = uint128(bound(sharesRedeemed, 1, sharesMinted));
         vm.assume(receiver != users.liquidityProvider);
         vm.assume(receiver != address(pool));
         vm.assume(beneficiary != owner);

--- a/test/fuzz/Tranche/Withdraw.fuzz.t.sol
+++ b/test/fuzz/Tranche/Withdraw.fuzz.t.sol
@@ -12,6 +12,7 @@ import { TrancheErrors } from "../../../src/libraries/Errors.sol";
 /**
  * @notice Fuzz tests for the function "withdraw" of contract "Tranche".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract Withdraw_Tranche_Fuzz_Test is Tranche_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -51,7 +52,7 @@ contract Withdraw_Tranche_Fuzz_Test is Tranche_Fuzz_Test {
         address unprivilegedAddress
     ) public {
         vm.assume(unprivilegedAddress != owner);
-        vm.assume(assets > 0);
+        assets = uint128(bound(assets, 1, type(uint128).max));
 
         vm.prank(users.liquidityProvider);
         tranche.deposit(assets, owner);
@@ -70,8 +71,8 @@ contract Withdraw_Tranche_Fuzz_Test is Tranche_Fuzz_Test {
         address beneficiary
     ) public {
         vm.assume(beneficiary != owner);
-        vm.assume(assetsDeposited > 0);
-        vm.assume(assetsDeposited < sharesAllowed);
+        assetsDeposited = uint128(bound(assetsDeposited, 1, type(uint128).max - 1));
+        sharesAllowed = uint128(bound(sharesAllowed, uint256(assetsDeposited) + 1, type(uint128).max));
 
         vm.prank(users.liquidityProvider);
         tranche.deposit(assetsDeposited, owner);
@@ -91,8 +92,8 @@ contract Withdraw_Tranche_Fuzz_Test is Tranche_Fuzz_Test {
         address owner,
         address receiver
     ) public {
-        vm.assume(assetsDeposited > 0);
-        vm.assume(assetsDeposited < assetsWithdrawn);
+        assetsDeposited = uint128(bound(assetsDeposited, 1, type(uint128).max - 1));
+        assetsWithdrawn = uint128(bound(assetsWithdrawn, uint256(assetsDeposited) + 1, type(uint128).max));
 
         vm.prank(users.liquidityProvider);
         tranche.deposit(assetsDeposited, owner);
@@ -109,8 +110,8 @@ contract Withdraw_Tranche_Fuzz_Test is Tranche_Fuzz_Test {
         address owner,
         address receiver
     ) public {
-        vm.assume(assetsDeposited > 0);
-        vm.assume(assetsDeposited >= assetsWithdrawn);
+        assetsDeposited = uint128(bound(assetsDeposited, 1, type(uint128).max));
+        assetsWithdrawn = uint128(bound(assetsWithdrawn, 0, assetsDeposited));
         vm.assume(receiver != users.liquidityProvider);
         vm.assume(receiver != address(pool));
 
@@ -135,9 +136,9 @@ contract Withdraw_Tranche_Fuzz_Test is Tranche_Fuzz_Test {
         address owner,
         address beneficiary
     ) public {
-        vm.assume(assetsDeposited > 0);
-        vm.assume(assetsDeposited >= assetsWithdrawn);
-        vm.assume(sharesAllowed >= assetsWithdrawn);
+        assetsDeposited = uint128(bound(assetsDeposited, 1, type(uint128).max));
+        assetsWithdrawn = uint128(bound(assetsWithdrawn, 0, assetsDeposited));
+        sharesAllowed = uint128(bound(sharesAllowed, assetsWithdrawn, type(uint128).max));
         vm.assume(receiver != users.liquidityProvider);
         vm.assume(receiver != address(pool));
         vm.assume(beneficiary != owner);
@@ -166,8 +167,8 @@ contract Withdraw_Tranche_Fuzz_Test is Tranche_Fuzz_Test {
         address owner,
         address beneficiary
     ) public {
-        vm.assume(assetsDeposited > 0);
-        vm.assume(assetsDeposited >= assetsWithdrawn);
+        assetsDeposited = uint128(bound(assetsDeposited, 1, type(uint128).max));
+        assetsWithdrawn = uint128(bound(assetsWithdrawn, 0, assetsDeposited));
         vm.assume(receiver != users.liquidityProvider);
         vm.assume(receiver != address(pool));
         vm.assume(beneficiary != owner);

--- a/test/fuzz/TrancheWrapper/Deposit.fuzz.t.sol
+++ b/test/fuzz/TrancheWrapper/Deposit.fuzz.t.sol
@@ -52,7 +52,7 @@ contract Deposit_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
     }
 
     function testFuzz_Success_deposit(uint128 assets, address receiver) public {
-        vm.assume(assets > 0);
+        assets = uint128(bound(assets, 1, type(uint128).max));
 
         vm.prank(users.liquidityProvider);
         trancheWrapper.deposit(assets, receiver);
@@ -98,7 +98,7 @@ contract Deposit_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
     }
 
     function testFuzz_Success_deposit_sync(uint128 assets, address receiver) public {
-        vm.assume(assets > 3);
+        assets = uint128(bound(assets, 3 + 1, type(uint128).max));
 
         vm.prank(users.liquidityProvider);
         trancheWrapper.deposit(assets / 3, receiver);

--- a/test/fuzz/TrancheWrapper/MaxMint.fuzz.t.sol
+++ b/test/fuzz/TrancheWrapper/MaxMint.fuzz.t.sol
@@ -11,6 +11,7 @@ import { stdStorage, StdStorage } from "../../../lib/accounts-v2/lib/forge-std/s
 /**
  * @notice Fuzz tests for the function "totalAssets" of contract "Tranche".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract MaxMint_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////
@@ -47,8 +48,8 @@ contract MaxMint_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
         uint128 totalLiquidity,
         uint128 liquidityOf
     ) public {
-        vm.assume(liquidityOf > 0);
-        vm.assume(liquidityOf <= totalLiquidity);
+        liquidityOf = uint128(bound(liquidityOf, 1, type(uint128).max));
+        totalLiquidity = uint128(bound(totalLiquidity, liquidityOf, type(uint128).max));
 
         vm.prank(users.owner);
         pool.setTotalRealisedLiquidity(totalLiquidity);
@@ -66,9 +67,9 @@ contract MaxMint_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
         uint128 liquidityOf,
         uint128 totalShares
     ) public {
-        vm.assume(liquidityOf > 0);
-        vm.assume(totalShares > 0);
-        vm.assume(liquidityOf <= totalLiquidity);
+        liquidityOf = uint128(bound(liquidityOf, 1, type(uint128).max));
+        totalShares = uint128(bound(totalShares, 1, type(uint128).max));
+        totalLiquidity = uint128(bound(totalLiquidity, liquidityOf, type(uint128).max));
 
         vm.prank(users.owner);
         pool.setTotalRealisedLiquidity(totalLiquidity);

--- a/test/fuzz/TrancheWrapper/MaxRedeem.fuzz.t.sol
+++ b/test/fuzz/TrancheWrapper/MaxRedeem.fuzz.t.sol
@@ -11,6 +11,7 @@ import { stdStorage, StdStorage } from "../../../lib/accounts-v2/lib/forge-std/s
 /**
  * @notice Fuzz tests for the function "totalAssets" of contract "Tranche".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract MaxRedeem_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////
@@ -57,10 +58,13 @@ contract MaxRedeem_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
         uint128 claimableLiquidityOfTranche,
         uint128 availableLiquidityOfTranche
     ) public {
-        vm.assume(shares <= totalShares);
-        vm.assume(claimableLiquidityOfTranche <= totalLiquidity);
-        vm.assume(availableLiquidityOfTranche <= totalLiquidity);
-        if (totalShares > 0) vm.assume(claimableLiquidityOfTranche > 0);
+        if (totalShares > 0) {
+            totalLiquidity = uint128(bound(totalLiquidity, 1, type(uint128).max));
+        }
+        shares = uint128(bound(shares, 0, totalShares));
+        claimableLiquidityOfTranche =
+            uint128(bound(claimableLiquidityOfTranche, totalShares > 0 ? 1 : 0, totalLiquidity));
+        availableLiquidityOfTranche = uint128(bound(availableLiquidityOfTranche, 0, totalLiquidity));
 
         stdstore.target(address(tranche))
             .sig(pool.balanceOf.selector)
@@ -95,10 +99,13 @@ contract MaxRedeem_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
         uint128 claimableLiquidityOfTranche,
         uint128 availableLiquidityOfTranche
     ) public {
-        vm.assume(shares <= totalShares);
-        vm.assume(claimableLiquidityOfTranche <= totalLiquidity);
-        vm.assume(availableLiquidityOfTranche <= totalLiquidity);
-        if (totalShares > 0) vm.assume(claimableLiquidityOfTranche > 0);
+        if (totalShares > 0) {
+            totalLiquidity = uint128(bound(totalLiquidity, 1, type(uint128).max));
+        }
+        shares = uint128(bound(shares, 0, totalShares));
+        claimableLiquidityOfTranche =
+            uint128(bound(claimableLiquidityOfTranche, totalShares > 0 ? 1 : 0, totalLiquidity));
+        availableLiquidityOfTranche = uint128(bound(availableLiquidityOfTranche, 0, totalLiquidity));
 
         stdstore.target(address(tranche))
             .sig(pool.balanceOf.selector)

--- a/test/fuzz/TrancheWrapper/MaxWithdraw.fuzz.t.sol
+++ b/test/fuzz/TrancheWrapper/MaxWithdraw.fuzz.t.sol
@@ -11,6 +11,7 @@ import { stdStorage, StdStorage } from "../../../lib/accounts-v2/lib/forge-std/s
 /**
  * @notice Fuzz tests for the function "totalAssets" of contract "Tranche".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract MaxWithdraw_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////
@@ -57,9 +58,18 @@ contract MaxWithdraw_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
         uint128 claimableLiquidityOfTranche,
         uint128 availableLiquidityOfTranche
     ) public {
-        vm.assume(shares <= totalShares);
-        vm.assume(claimableLiquidityOfTranche <= totalLiquidity);
-        vm.assume(availableLiquidityOfTranche <= totalLiquidity);
+        shares = uint128(bound(shares, 0, totalShares));
+        claimableLiquidityOfTranche = uint128(bound(claimableLiquidityOfTranche, 0, totalLiquidity));
+
+        uint256 claimableAssets;
+        if (shares == 0) {
+            claimableAssets = 0;
+        } else {
+            claimableAssets = uint256(shares) * claimableLiquidityOfTranche / totalShares;
+        }
+
+        // And: The tranche holds enough underlying assets.
+        availableLiquidityOfTranche = uint128(bound(availableLiquidityOfTranche, claimableAssets, totalLiquidity));
 
         stdstore.target(address(tranche))
             .sig(pool.balanceOf.selector)
@@ -74,14 +84,6 @@ contract MaxWithdraw_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
             .sig(pool.balanceOf.selector)
             .with_key(address(pool))
             .checked_write(availableLiquidityOfTranche);
-
-        uint256 claimableAssets;
-        if (shares == 0) {
-            claimableAssets = 0;
-        } else {
-            claimableAssets = uint256(shares) * claimableLiquidityOfTranche / totalShares;
-        }
-        vm.assume(availableLiquidityOfTranche >= claimableAssets);
 
         assertEq(trancheWrapper.maxWithdraw(owner), claimableAssets);
     }
@@ -94,9 +96,18 @@ contract MaxWithdraw_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
         uint128 claimableLiquidityOfTranche,
         uint128 availableLiquidityOfTranche
     ) public {
-        vm.assume(shares <= totalShares);
-        vm.assume(claimableLiquidityOfTranche <= totalLiquidity);
-        vm.assume(availableLiquidityOfTranche <= totalLiquidity);
+        shares = uint128(bound(shares, 0, totalShares));
+        claimableLiquidityOfTranche = uint128(bound(claimableLiquidityOfTranche, 0, totalLiquidity));
+
+        uint256 claimableAssets;
+        if (shares == 0) {
+            claimableAssets = 0;
+        } else {
+            claimableAssets = uint256(shares) * claimableLiquidityOfTranche / totalShares;
+        }
+
+        // And: The underlying assets are the limiting factor.
+        availableLiquidityOfTranche = uint128(bound(availableLiquidityOfTranche, 0, claimableAssets));
 
         stdstore.target(address(tranche))
             .sig(pool.balanceOf.selector)
@@ -111,14 +122,6 @@ contract MaxWithdraw_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
             .sig(pool.balanceOf.selector)
             .with_key(address(pool))
             .checked_write(availableLiquidityOfTranche);
-
-        uint256 claimableAssets;
-        if (shares == 0) {
-            claimableAssets = 0;
-        } else {
-            claimableAssets = uint256(shares) * claimableLiquidityOfTranche / totalShares;
-        }
-        vm.assume(availableLiquidityOfTranche <= claimableAssets);
 
         assertEq(trancheWrapper.maxWithdraw(owner), availableLiquidityOfTranche);
     }

--- a/test/fuzz/TrancheWrapper/Mint.fuzz.t.sol
+++ b/test/fuzz/TrancheWrapper/Mint.fuzz.t.sol
@@ -37,7 +37,7 @@ contract Mint_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
     }
 
     function testFuzz_Success_mint(uint128 shares, address receiver) public {
-        vm.assume(shares > 0);
+        shares = uint128(bound(shares, 1, type(uint128).max));
 
         vm.prank(users.liquidityProvider);
         trancheWrapper.mint(shares, receiver);

--- a/test/fuzz/TrancheWrapper/Redeem.fuzz.t.sol
+++ b/test/fuzz/TrancheWrapper/Redeem.fuzz.t.sol
@@ -38,7 +38,7 @@ contract Redeem_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
         address unprivilegedAddress
     ) public {
         vm.assume(unprivilegedAddress != owner);
-        vm.assume(shares > 0);
+        shares = uint128(bound(shares, 1, type(uint128).max));
 
         vm.prank(users.liquidityProvider);
         trancheWrapper.mint(shares, owner);
@@ -57,8 +57,8 @@ contract Redeem_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
         address beneficiary
     ) public {
         vm.assume(beneficiary != owner);
-        vm.assume(sharesMinted > 0);
-        vm.assume(sharesMinted < sharesAllowed);
+        sharesMinted = uint128(bound(sharesMinted, 1, type(uint128).max - 1));
+        sharesAllowed = uint128(bound(sharesAllowed, uint256(sharesMinted) + 1, type(uint128).max));
 
         vm.prank(users.liquidityProvider);
         trancheWrapper.mint(sharesMinted, owner);
@@ -78,8 +78,8 @@ contract Redeem_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
         address owner,
         address receiver
     ) public {
-        vm.assume(sharesMinted > 0);
-        vm.assume(sharesMinted < sharesRedeemed);
+        sharesMinted = uint128(bound(sharesMinted, 1, type(uint128).max - 1));
+        sharesRedeemed = uint128(bound(sharesRedeemed, uint256(sharesMinted) + 1, type(uint128).max));
 
         vm.prank(users.liquidityProvider);
         trancheWrapper.mint(sharesMinted, owner);
@@ -96,9 +96,8 @@ contract Redeem_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
         address owner,
         address receiver
     ) public {
-        vm.assume(sharesMinted > 0);
-        vm.assume(sharesRedeemed > 0);
-        vm.assume(sharesMinted >= sharesRedeemed);
+        sharesMinted = uint128(bound(sharesMinted, 1, type(uint128).max));
+        sharesRedeemed = uint128(bound(sharesRedeemed, 1, sharesMinted));
         vm.assume(receiver != users.liquidityProvider);
         vm.assume(receiver != address(pool));
 
@@ -120,9 +119,8 @@ contract Redeem_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
         address owner,
         address receiver
     ) public {
-        vm.assume(sharesMinted > 0);
-        vm.assume(sharesRedeemed > 0);
-        vm.assume(sharesMinted >= sharesRedeemed);
+        sharesMinted = uint128(bound(sharesMinted, 1, type(uint128).max));
+        sharesRedeemed = uint128(bound(sharesRedeemed, 1, sharesMinted));
         vm.assume(receiver != users.liquidityProvider);
         vm.assume(receiver != address(pool));
 
@@ -186,10 +184,9 @@ contract Redeem_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
         address owner,
         address beneficiary
     ) public {
-        vm.assume(sharesMinted > 0);
-        vm.assume(sharesRedeemed > 0);
-        vm.assume(sharesMinted >= sharesRedeemed);
-        vm.assume(sharesAllowed >= sharesRedeemed);
+        sharesMinted = uint128(bound(sharesMinted, 1, type(uint128).max));
+        sharesRedeemed = uint128(bound(sharesRedeemed, 1, sharesMinted));
+        sharesAllowed = uint128(bound(sharesAllowed, sharesRedeemed, type(uint128).max));
         vm.assume(receiver != users.liquidityProvider);
         vm.assume(receiver != address(pool));
         vm.assume(beneficiary != owner);
@@ -218,9 +215,8 @@ contract Redeem_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
         address owner,
         address beneficiary
     ) public {
-        vm.assume(sharesMinted > 0);
-        vm.assume(sharesRedeemed > 0);
-        vm.assume(sharesMinted >= sharesRedeemed);
+        sharesMinted = uint128(bound(sharesMinted, 1, type(uint128).max));
+        sharesRedeemed = uint128(bound(sharesRedeemed, 1, sharesMinted));
         vm.assume(receiver != users.liquidityProvider);
         vm.assume(receiver != address(pool));
         vm.assume(beneficiary != owner);

--- a/test/fuzz/TrancheWrapper/Withdraw.fuzz.t.sol
+++ b/test/fuzz/TrancheWrapper/Withdraw.fuzz.t.sol
@@ -31,7 +31,7 @@ contract Withdraw_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
         address unprivilegedAddress
     ) public {
         vm.assume(unprivilegedAddress != owner);
-        vm.assume(assets > 0);
+        assets = uint128(bound(assets, 1, type(uint128).max));
 
         vm.prank(users.liquidityProvider);
         trancheWrapper.deposit(assets, owner);
@@ -50,8 +50,8 @@ contract Withdraw_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
         address beneficiary
     ) public {
         vm.assume(beneficiary != owner);
-        vm.assume(assetsDeposited > 0);
-        vm.assume(assetsDeposited < sharesAllowed);
+        assetsDeposited = uint128(bound(assetsDeposited, 1, type(uint128).max - 1));
+        sharesAllowed = uint128(bound(sharesAllowed, uint256(assetsDeposited) + 1, type(uint128).max));
 
         vm.prank(users.liquidityProvider);
         trancheWrapper.deposit(assetsDeposited, owner);
@@ -72,8 +72,8 @@ contract Withdraw_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
         address owner,
         address receiver
     ) public {
-        vm.assume(assetsDeposited > 0);
-        vm.assume(assetsDeposited < assetsWithdrawn);
+        assetsDeposited = uint128(bound(assetsDeposited, 1, type(uint128).max - 1));
+        assetsWithdrawn = uint128(bound(assetsWithdrawn, uint256(assetsDeposited) + 1, type(uint128).max));
 
         vm.prank(users.liquidityProvider);
         trancheWrapper.deposit(assetsDeposited, owner);
@@ -90,8 +90,8 @@ contract Withdraw_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
         address owner,
         address receiver
     ) public {
-        vm.assume(assetsDeposited > 0);
-        vm.assume(assetsDeposited >= assetsWithdrawn);
+        assetsDeposited = uint128(bound(assetsDeposited, 1, type(uint128).max));
+        assetsWithdrawn = uint128(bound(assetsWithdrawn, 0, assetsDeposited));
         vm.assume(receiver != users.liquidityProvider);
         vm.assume(receiver != address(pool));
 
@@ -113,8 +113,8 @@ contract Withdraw_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
         address owner,
         address receiver
     ) public {
-        vm.assume(assetsDeposited > 0);
-        vm.assume(assetsDeposited >= assetsWithdrawn);
+        assetsDeposited = uint128(bound(assetsDeposited, 1, type(uint128).max));
+        assetsWithdrawn = uint128(bound(assetsWithdrawn, 0, assetsDeposited));
         vm.assume(receiver != users.liquidityProvider);
         vm.assume(receiver != address(pool));
 
@@ -136,8 +136,8 @@ contract Withdraw_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
         address owner,
         address receiver
     ) public {
-        vm.assume(assetsDeposited > 0);
-        vm.assume(assetsDeposited >= assetsWithdrawn);
+        assetsDeposited = uint128(bound(assetsDeposited, 1, type(uint128).max));
+        assetsWithdrawn = uint128(bound(assetsWithdrawn, 0, assetsDeposited));
         vm.assume(receiver != users.liquidityProvider);
         vm.assume(receiver != address(pool));
 
@@ -201,9 +201,9 @@ contract Withdraw_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
         address owner,
         address beneficiary
     ) public {
-        vm.assume(assetsDeposited > 0);
-        vm.assume(assetsDeposited >= assetsWithdrawn);
-        vm.assume(sharesAllowed >= assetsWithdrawn);
+        assetsDeposited = uint128(bound(assetsDeposited, 1, type(uint128).max));
+        assetsWithdrawn = uint128(bound(assetsWithdrawn, 0, assetsDeposited));
+        sharesAllowed = uint128(bound(sharesAllowed, assetsWithdrawn, type(uint128).max));
         vm.assume(receiver != users.liquidityProvider);
         vm.assume(receiver != address(pool));
         vm.assume(beneficiary != owner);
@@ -234,8 +234,8 @@ contract Withdraw_TrancheWrapper_Fuzz_Test is TrancheWrapper_Fuzz_Test {
         address owner,
         address beneficiary
     ) public {
-        vm.assume(assetsDeposited > 0);
-        vm.assume(assetsDeposited >= assetsWithdrawn);
+        assetsDeposited = uint128(bound(assetsDeposited, 1, type(uint128).max));
+        assetsWithdrawn = uint128(bound(assetsWithdrawn, 0, assetsDeposited));
         vm.assume(receiver != users.liquidityProvider);
         vm.assume(receiver != address(pool));
         vm.assume(beneficiary != owner);

--- a/test/fuzz/liquidators/LiquidatorL1/Bid.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL1/Bid.fuzz.t.sol
@@ -252,15 +252,15 @@ contract Bid_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
         assertEq(inAuction, false);
     }
 
-    function testFuzz_Success_bid_FromContract_Partial(uint112 amountLoaned, uint112 bidAssetAmount, bytes memory data)
+    function testFuzz_Success_bid_FromContract_Partial(uint256 amountToken1, uint112 bidAssetAmount, bytes memory data)
         public
     {
         // Given: Bidder is a contract.
         Bidder bidder = new Bidder();
 
-        // And: The account auction is initiated
-        amountLoaned = uint112(bound(amountLoaned, 1, type(uint112).max - 1));
-        initiateLiquidation(amountLoaned);
+        // And: The account auction is initiated, with token1 as collateral and stable1 as numeraire.
+        amountToken1 = bound(amountToken1, 1e12, 1e30);
+        initiateLiquidationToken1(amountToken1);
 
         uint256[] memory originalAssetAmounts = liquidator_.getAuctionAssetAmounts(address(account));
         uint256 originalAmount = originalAssetAmounts[0];
@@ -285,6 +285,7 @@ contract Bid_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
         // Get Initial balances.
         uint256 initialBalancePool = mockERC20.stable1.balanceOf(address(pool));
         uint256 initialBalanceBidder = mockERC20.stable1.balanceOf(address(bidder));
+        uint256 initialCollateralBidder = mockERC20.token1.balanceOf(address(bidder));
 
         // When: Bidder bids for the asset
         // Then: Bidder contract gets called with the actual amounts transferred and actual bid price.
@@ -294,21 +295,21 @@ contract Bid_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
 
         // And: Tokens are transferred.
         assertEq(mockERC20.stable1.balanceOf(address(pool)), initialBalancePool + price);
-        // ToDo: collateral and numeraire are both stable1 -> balance of bidder increases and decreases -> use two different tokens.
-        assertEq(mockERC20.stable1.balanceOf(address(bidder)), initialBalanceBidder - price + bidAssetAmount);
+        assertEq(mockERC20.stable1.balanceOf(address(bidder)), initialBalanceBidder - price);
+        assertEq(mockERC20.token1.balanceOf(address(bidder)), initialCollateralBidder + bidAssetAmount);
     }
 
     function testFuzz_Success_bid_FromContract_BidExceeding(
-        uint112 amountLoaned,
+        uint256 amountToken1,
         uint112 bidAssetAmount,
         bytes memory data
     ) public {
         // Given: Bidder is a contract.
         Bidder bidder = new Bidder();
 
-        // And: The account auction is initiated
-        amountLoaned = uint112(bound(amountLoaned, 1, type(uint112).max - 1));
-        initiateLiquidation(amountLoaned);
+        // And: The account auction is initiated, with token1 as collateral and stable1 as numeraire.
+        amountToken1 = bound(amountToken1, 1e12, 1e30);
+        initiateLiquidationToken1(amountToken1);
 
         uint256[] memory originalAssetAmounts = liquidator_.getAuctionAssetAmounts(address(account));
         uint256 originalAmount = originalAssetAmounts[0];
@@ -333,6 +334,7 @@ contract Bid_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
         // Get Initial balances.
         uint256 initialBalancePool = mockERC20.stable1.balanceOf(address(pool));
         uint256 initialBalanceBidder = mockERC20.stable1.balanceOf(address(bidder));
+        uint256 initialCollateralBidder = mockERC20.token1.balanceOf(address(bidder));
 
         // When: Bidder bids for the asset
         // Then: Bidder contract gets called with the actual amounts transferred and actual bid price.
@@ -342,7 +344,7 @@ contract Bid_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
 
         // And: Tokens are transferred.
         assertEq(mockERC20.stable1.balanceOf(address(pool)), initialBalancePool + price);
-        // ToDo: collateral and numeraire are both stable1 -> balance of bidder increases and decreases -> use two different tokens.
-        assertEq(mockERC20.stable1.balanceOf(address(bidder)), initialBalanceBidder - price + originalAmount);
+        assertEq(mockERC20.stable1.balanceOf(address(bidder)), initialBalanceBidder - price);
+        assertEq(mockERC20.token1.balanceOf(address(bidder)), initialCollateralBidder + originalAmount);
     }
 }

--- a/test/fuzz/liquidators/LiquidatorL1/Bid.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL1/Bid.fuzz.t.sol
@@ -48,8 +48,7 @@ contract Bid_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
         address bidder = address(srTranche);
 
         // And: The account auction is initiated
-        vm.assume(amountLoaned > 3);
-        vm.assume(amountLoaned <= (type(uint112).max / 150) * 100);
+        amountLoaned = uint112(bound(amountLoaned, 3 + 1, (type(uint112).max / 150) * 100));
         initiateLiquidation(amountLoaned);
         bool endAuction = false;
 
@@ -61,8 +60,7 @@ contract Bid_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
 
     function testFuzz_Revert_bid_AssetAmountsLonger(address bidder, uint112 amountLoaned, bytes memory data) public {
         // Given: The account auction is initiated
-        vm.assume(amountLoaned > 1);
-        vm.assume(amountLoaned <= (type(uint112).max / 300) * 100);
+        amountLoaned = uint112(bound(amountLoaned, 1 + 1, (type(uint112).max / 300) * 100));
         initiateLiquidation(amountLoaned);
         bool endAuction = false;
 
@@ -78,8 +76,7 @@ contract Bid_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
         address bidder = address(srTranche);
 
         // And: The account auction is initiated
-        vm.assume(amountLoaned > 3);
-        vm.assume(amountLoaned <= (type(uint112).max / 150) * 100);
+        amountLoaned = uint112(bound(amountLoaned, 3 + 1, (type(uint112).max / 150) * 100));
         initiateLiquidation(amountLoaned);
         bool endAuction = false;
 
@@ -98,8 +95,7 @@ contract Bid_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
 
         // And: The account auction is initiated
         vm.assume(bidder != address(0) && bidder != users.liquidityProvider && bidder != address(srTranche));
-        vm.assume(amountLoaned > 3);
-        vm.assume(amountLoaned <= (type(uint112).max / 150) * 100);
+        amountLoaned = uint112(bound(amountLoaned, 3 + 1, (type(uint112).max / 150) * 100));
         initiateLiquidation(amountLoaned);
         bool endAuction = false;
 
@@ -119,10 +115,8 @@ contract Bid_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
         vm.assume(bidder.code.length == 0);
 
         // And: The account auction is initiated
-        vm.assume(bidder != address(0));
         vm.assume(bidder != address(0) && bidder != users.liquidityProvider && bidder != address(srTranche));
-        vm.assume(amountLoaned > 3);
-        vm.assume(amountLoaned <= (type(uint112).max / 150) * 100);
+        amountLoaned = uint112(bound(amountLoaned, 3 + 1, (type(uint112).max / 150) * 100));
         initiateLiquidation(amountLoaned);
         bool endAuction = false;
 
@@ -148,8 +142,7 @@ contract Bid_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
         vm.assume(bidder.code.length == 0);
 
         vm.assume(bidder != address(0));
-        vm.assume(amountLoaned > 12);
-        vm.assume(amountLoaned <= (type(uint112).max / 300) * 100);
+        amountLoaned = uint112(bound(amountLoaned, 12 + 1, (type(uint112).max / 300) * 100));
 
         // Given: Sequencer did not go down during the auction.
         liquidationStartTime =
@@ -187,8 +180,7 @@ contract Bid_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
 
         // And: The account auction is initiated
         vm.assume(bidder != address(0));
-        vm.assume(amountLoaned > 12);
-        vm.assume(amountLoaned <= (type(uint112).max / 300) * 100);
+        amountLoaned = uint112(bound(amountLoaned, 12 + 1, (type(uint112).max / 300) * 100));
         initiateLiquidation(amountLoaned);
         bool endAuction = false;
 
@@ -223,8 +215,7 @@ contract Bid_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
 
         // And: The account auction is initiated
         vm.assume(bidder != address(0));
-        vm.assume(amountLoaned > 2);
-        vm.assume(amountLoaned <= (type(uint112).max / 300) * 100);
+        amountLoaned = uint112(bound(amountLoaned, 2 + 1, (type(uint112).max / 300) * 100));
         initiateLiquidation(amountLoaned);
         bool endAuction = false;
 

--- a/test/fuzz/liquidators/LiquidatorL1/CalculateBidPrice.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL1/CalculateBidPrice.fuzz.t.sol
@@ -43,8 +43,7 @@ contract CalculateBidPrice_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
         liquidator_.setAuctionCurveParameters(halfLifeTime, cutoffTime, startPriceMultiplier, minPriceMultiplier);
 
         // And: The account auction is initiated.
-        vm.assume(amountLoaned > 1);
-        vm.assume(amountLoaned <= (type(uint112).max / 300) * 100);
+        amountLoaned = uint112(bound(amountLoaned, 1 + 1, (type(uint112).max / 300) * 100));
         initiateLiquidation(amountLoaned);
 
         // And: A timestamp far beyond the cutoffTime, where the price curve underflows the LogExpMath precision.

--- a/test/fuzz/liquidators/LiquidatorL1/GetAssetShares.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL1/GetAssetShares.fuzz.t.sol
@@ -53,7 +53,7 @@ contract GetAssetShares_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
             assetValues[i].assetValue = bound(assetValues[i].assetValue, 0, type(uint112).max);
             totalValue += assetValues[i].assetValue;
         }
-        vm.assume(totalValue > 0);
+        totalValue = bound(totalValue, 1, type(uint256).max);
 
         vm.assume(totalValue != 0);
 

--- a/test/fuzz/liquidators/LiquidatorL1/GetBidPrice.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL1/GetBidPrice.fuzz.t.sol
@@ -26,8 +26,7 @@ contract GetBidPrice_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
 
     function testFuzz_Revert_getBidPrice_AssetAmountsShorter(address bidder, uint112 amountLoaned) public {
         // Given: The account auction is initiated
-        vm.assume(amountLoaned > 1);
-        vm.assume(amountLoaned <= (type(uint112).max / 300) * 100);
+        amountLoaned = uint112(bound(amountLoaned, 1 + 1, (type(uint112).max / 300) * 100));
         initiateLiquidation(amountLoaned);
 
         // When: getBidPrice is called with fewer asset amounts than the auction.
@@ -40,8 +39,7 @@ contract GetBidPrice_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
 
     function testFuzz_Revert_getBidPrice_AfterCutoff(address bidder, uint112 amountLoaned, uint32 timePassed) public {
         // Given: The account auction is initiated.
-        vm.assume(amountLoaned > 1);
-        vm.assume(amountLoaned <= (type(uint112).max / 300) * 100);
+        amountLoaned = uint112(bound(amountLoaned, 1 + 1, (type(uint112).max / 300) * 100));
         initiateLiquidation(amountLoaned);
 
         // And: A timestamp far beyond the cutoffTime, where the price curve underflows the LogExpMath precision.

--- a/test/fuzz/liquidators/LiquidatorL1/LiquidateAccount.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL1/LiquidateAccount.fuzz.t.sol
@@ -15,7 +15,7 @@ import { stdStorage, StdStorage } from "../../../../lib/accounts-v2/lib/forge-st
 /**
  * @notice Fuzz tests for the function "liquidateAccount" of contract "LiquidatorL1".
  */
-// forge-lint: disable-next-item(divide-before-multiply)
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract LiquidateAccount_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
     using FixedPointMathLib for uint256;
     using stdStorage for StdStorage;
@@ -45,8 +45,7 @@ contract LiquidateAccount_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
     {
         // Given: Account auction is already started
         bytes3 emptyBytes3;
-        vm.assume(amountLoaned > 1);
-        vm.assume(amountLoaned <= (type(uint112).max / 150) * 100); // No overflow when debt is increased
+        amountLoaned = uint112(bound(amountLoaned, 1 + 1, (type(uint112).max / 150) * 100));
         depositErc20InAccount(account, mockERC20.stable1, amountLoaned);
         vm.prank(users.liquidityProvider);
         mockERC20.stable1.approve(address(pool), type(uint256).max);
@@ -111,8 +110,7 @@ contract LiquidateAccount_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
     ) public {
         // Given: Account has debt
         bytes3 emptyBytes3;
-        vm.assume(amountLoaned > 0);
-        vm.assume(amountLoaned <= type(uint112).max - 2); // No overflow when debt is increased
+        amountLoaned = uint112(bound(amountLoaned, 1, type(uint112).max - 2)); // No overflow when debt is increased
         depositErc20InAccount(account, mockERC20.stable1, amountLoaned);
         vm.prank(users.liquidityProvider);
         mockERC20.stable1.approve(address(pool), type(uint256).max);
@@ -139,9 +137,10 @@ contract LiquidateAccount_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
         uint80 maxReward,
         address liquidationInitiator
     ) public {
-        vm.assume(amountLoaned > 1);
-        vm.assume(amountLoaned <= (type(uint112).max / 300) * 100); // No overflow when debt is increased
-        vm.assume(uint32(initiationWeight) + penaltyWeight + terminationWeight <= 1100);
+        amountLoaned = uint112(bound(amountLoaned, 1 + 1, (type(uint112).max / 300) * 100)); // No overflow when debt is increased
+        initiationWeight = uint16(bound(initiationWeight, 0, 1100));
+        penaltyWeight = uint16(bound(penaltyWeight, 0, 1100 - initiationWeight));
+        terminationWeight = uint16(bound(terminationWeight, 0, 1100 - initiationWeight - penaltyWeight));
 
         // Given: Account has debt
         bytes3 emptyBytes3;
@@ -187,12 +186,10 @@ contract LiquidateAccount_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
         uint80 maxReward,
         address liquidationInitiator
     ) public {
-        vm.assume(amountLoaned > 1);
-        vm.assume(amountLoaned <= (type(uint112).max / 300) * 100); // No overflow when debt is increased
-        vm.assume(uint256(amountLoaned) * initiationWeight <= (type(uint256).max));
-        vm.assume(uint256(amountLoaned) * terminationWeight <= (type(uint256).max));
-        vm.assume(uint256(amountLoaned) * penaltyWeight <= (type(uint256).max));
-        vm.assume(uint32(initiationWeight) + penaltyWeight + terminationWeight <= 1100);
+        amountLoaned = uint112(bound(amountLoaned, 1 + 1, (type(uint112).max / 300) * 100)); // No overflow when debt is increased
+        initiationWeight = uint16(bound(initiationWeight, 0, 1100));
+        penaltyWeight = uint16(bound(penaltyWeight, 0, 1100 - initiationWeight));
+        terminationWeight = uint16(bound(terminationWeight, 0, 1100 - initiationWeight - penaltyWeight));
 
         // Given: Account has debt
         bytes3 emptyBytes3;
@@ -253,9 +250,10 @@ contract LiquidateAccount_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
         uint80 maxReward,
         address liquidationInitiator
     ) public {
-        vm.assume(amountLoaned > 1);
-        vm.assume(amountLoaned <= (type(uint112).max / 300) * 100); // No overflow when debt is increased
-        vm.assume(uint16(initiationWeight) + penaltyWeight + terminationWeight <= 1100);
+        amountLoaned = uint112(bound(amountLoaned, 1 + 1, (type(uint112).max / 300) * 100)); // No overflow when debt is increased
+        initiationWeight = uint8(bound(initiationWeight, 0, 1100));
+        penaltyWeight = uint8(bound(penaltyWeight, 0, 1100 - initiationWeight));
+        terminationWeight = uint8(bound(terminationWeight, 0, 1100 - initiationWeight - penaltyWeight));
 
         // Given: Account has debt
         bytes3 emptyBytes3;
@@ -304,9 +302,10 @@ contract LiquidateAccount_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
         uint80 maxReward,
         address liquidationInitiator
     ) public {
-        vm.assume(amountLoaned > 1);
-        vm.assume(amountLoaned <= (type(uint112).max / 300) * 100); // No overflow when debt is increased
-        vm.assume(uint16(initiationWeight) + penaltyWeight + terminationWeight <= 1100);
+        amountLoaned = uint112(bound(amountLoaned, 1 + 1, (type(uint112).max / 300) * 100)); // No overflow when debt is increased
+        initiationWeight = uint8(bound(initiationWeight, 0, 1100));
+        penaltyWeight = uint8(bound(penaltyWeight, 0, 1100 - initiationWeight));
+        terminationWeight = uint8(bound(terminationWeight, 0, 1100 - initiationWeight - penaltyWeight));
 
         // Given: Account has debt
         bytes3 emptyBytes3;

--- a/test/fuzz/liquidators/LiquidatorL1/SettleAuction.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL1/SettleAuction.fuzz.t.sol
@@ -14,7 +14,7 @@ import { stdStorage, StdStorage } from "../../../../lib/accounts-v2/lib/forge-st
  * @dev "_settleAuction" has no own reverts, it returns a bool indicating if a termination condition was met.
  * Each test asserts the returned bool and the side effects of the matched condition.
  */
-// forge-lint: disable-next-item(unsafe-typecast)
+// forge-lint: disable-next-item(unsafe-typecast,divide-before-multiply)
 contract SettleAuction_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////
@@ -219,9 +219,8 @@ contract SettleAuction_LiquidatorL1_Fuzz_Test is LiquidatorL1_Fuzz_Test {
         vm.assume(bidder != address(0));
 
         // And: The account auction is initiated.
-        vm.assume(amountLoaned > 12);
+        amountLoaned = uint112(bound(amountLoaned, 12 + 1, (type(uint112).max / 300) * 100));
         // forge-lint: disable-next-line(divide-before-multiply)
-        vm.assume(amountLoaned <= (type(uint112).max / 300) * 100);
         initiateLiquidation(amountLoaned);
 
         // And: The auction price decayed below the open debt, within the cutoffTime.

--- a/test/fuzz/liquidators/LiquidatorL1/_LiquidatorL1.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL1/_LiquidatorL1.fuzz.t.sol
@@ -272,6 +272,49 @@ abstract contract LiquidatorL1_Fuzz_Test is Fuzz_Lending_Test {
                         HELPER FUNCTIONS
     /////////////////////////////////////////////////////////////// */
 
+    // forge-lint: disable-next-item(unsafe-typecast)
+    function initiateLiquidationToken1(uint256 amountToken1) public returns (uint256 amountLoaned) {
+        vm.prank(users.riskManager);
+        registry_.setRiskParametersOfPrimaryAsset(
+            address(pool), address(mockERC20.token1), 0, type(uint112).max, 1e4, 1e4
+        );
+
+        vm.startPrank(users.accountOwner);
+        account.closeMarginAccount();
+        account.openMarginAccount(address(pool));
+        vm.stopPrank();
+
+        depositErc20InAccount(account, mockERC20.token1, amountToken1);
+
+        address[] memory assetAddresses = new address[](1);
+        assetAddresses[0] = address(mockERC20.token1);
+        uint256[] memory assetIds = new uint256[](1);
+        uint256[] memory assetAmounts = new uint256[](1);
+        assetAmounts[0] = amountToken1;
+        amountLoaned = registry_.getCollateralValue(
+            address(mockERC20.stable1), address(pool), assetAddresses, assetIds, assetAmounts
+        );
+        vm.assume(amountLoaned > 2);
+        vm.assume(amountLoaned < type(uint112).max);
+
+        bytes3 emptyBytes3;
+        vm.prank(users.liquidityProvider);
+        mockERC20.stable1.approve(address(pool), type(uint256).max);
+        vm.prank(address(srTranche));
+        pool.depositInLendingPool(amountLoaned, users.liquidityProvider);
+        vm.prank(users.accountOwner);
+        pool.borrow(uint112(amountLoaned), address(account), users.accountOwner, emptyBytes3);
+
+        debt.setRealisedDebt(amountLoaned + 1);
+        stdstore.target(address(pool))
+            .sig(pool.liquidityOf.selector)
+            .with_key(address(srTranche))
+            .checked_write(amountLoaned + 1);
+        pool.setTotalRealisedLiquidity(uint128(amountLoaned + 1));
+
+        liquidator_.liquidateAccount(address(account));
+    }
+
     function initiateLiquidation(uint112 amountLoaned) public {
         initiateLiquidation(0, amountLoaned);
     }

--- a/test/fuzz/liquidators/LiquidatorL2/Bid.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL2/Bid.fuzz.t.sol
@@ -50,8 +50,7 @@ contract Bid_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
         bytes memory data
     ) public {
         // Given: The account auction is initiated
-        vm.assume(amountLoaned > 1);
-        vm.assume(amountLoaned <= (type(uint112).max / 300) * 100);
+        amountLoaned = uint112(bound(amountLoaned, 1 + 1, (type(uint112).max / 300) * 100));
         initiateLiquidation(amountLoaned);
 
         // And: The sequencer is down.
@@ -68,8 +67,7 @@ contract Bid_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
         address bidder = address(srTranche);
 
         // And: The account auction is initiated
-        vm.assume(amountLoaned > 3);
-        vm.assume(amountLoaned <= (type(uint112).max / 150) * 100);
+        amountLoaned = uint112(bound(amountLoaned, 3 + 1, (type(uint112).max / 150) * 100));
         initiateLiquidation(amountLoaned);
         bool endAuction = false;
 
@@ -81,8 +79,7 @@ contract Bid_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
 
     function testFuzz_Revert_bid_AssetAmountsLonger(address bidder, uint112 amountLoaned, bytes memory data) public {
         // Given: The account auction is initiated
-        vm.assume(amountLoaned > 1);
-        vm.assume(amountLoaned <= (type(uint112).max / 300) * 100);
+        amountLoaned = uint112(bound(amountLoaned, 1 + 1, (type(uint112).max / 300) * 100));
         initiateLiquidation(amountLoaned);
         bool endAuction = false;
 
@@ -98,8 +95,7 @@ contract Bid_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
         address bidder = address(srTranche);
 
         // And: The account auction is initiated
-        vm.assume(amountLoaned > 3);
-        vm.assume(amountLoaned <= (type(uint112).max / 150) * 100);
+        amountLoaned = uint112(bound(amountLoaned, 3 + 1, (type(uint112).max / 150) * 100));
         initiateLiquidation(amountLoaned);
         bool endAuction = false;
 
@@ -118,8 +114,7 @@ contract Bid_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
 
         // And: The account auction is initiated
         vm.assume(bidder != address(0) && bidder != users.liquidityProvider && bidder != address(srTranche));
-        vm.assume(amountLoaned > 3);
-        vm.assume(amountLoaned <= (type(uint112).max / 150) * 100);
+        amountLoaned = uint112(bound(amountLoaned, 3 + 1, (type(uint112).max / 150) * 100));
         initiateLiquidation(amountLoaned);
         bool endAuction = false;
 
@@ -139,10 +134,8 @@ contract Bid_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
         vm.assume(bidder.code.length == 0);
 
         // And: The account auction is initiated
-        vm.assume(bidder != address(0));
         vm.assume(bidder != address(0) && bidder != users.liquidityProvider && bidder != address(srTranche));
-        vm.assume(amountLoaned > 3);
-        vm.assume(amountLoaned <= (type(uint112).max / 150) * 100);
+        amountLoaned = uint112(bound(amountLoaned, 3 + 1, (type(uint112).max / 150) * 100));
         initiateLiquidation(amountLoaned);
         bool endAuction = false;
 
@@ -169,8 +162,7 @@ contract Bid_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
         vm.assume(bidder.code.length == 0);
 
         vm.assume(bidder != address(0));
-        vm.assume(amountLoaned > 12);
-        vm.assume(amountLoaned <= (type(uint112).max / 300) * 100);
+        amountLoaned = uint112(bound(amountLoaned, 12 + 1, (type(uint112).max / 300) * 100));
 
         // Given: Sequencer did not go down during the auction.
         liquidationStartTime =
@@ -216,8 +208,7 @@ contract Bid_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
         vm.assume(bidder.code.length == 0);
 
         vm.assume(bidder != address(0));
-        vm.assume(amountLoaned > 12);
-        vm.assume(amountLoaned <= (type(uint112).max / 300) * 100);
+        amountLoaned = uint112(bound(amountLoaned, 12 + 1, (type(uint112).max / 300) * 100));
 
         // Given: Sequencer did go down during the auction.
         sequencerStartedAt = uint32(bound(sequencerStartedAt, 2 days + 1, type(uint32).max));
@@ -261,8 +252,7 @@ contract Bid_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
 
         // And: The account auction is initiated
         vm.assume(bidder != address(0));
-        vm.assume(amountLoaned > 12);
-        vm.assume(amountLoaned <= (type(uint112).max / 300) * 100);
+        amountLoaned = uint112(bound(amountLoaned, 12 + 1, (type(uint112).max / 300) * 100));
         initiateLiquidation(amountLoaned);
         bool endAuction = false;
 
@@ -297,8 +287,7 @@ contract Bid_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
 
         // And: The account auction is initiated
         vm.assume(bidder != address(0));
-        vm.assume(amountLoaned > 2);
-        vm.assume(amountLoaned <= (type(uint112).max / 300) * 100);
+        amountLoaned = uint112(bound(amountLoaned, 2 + 1, (type(uint112).max / 300) * 100));
         initiateLiquidation(amountLoaned);
         bool endAuction = false;
 

--- a/test/fuzz/liquidators/LiquidatorL2/Bid.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL2/Bid.fuzz.t.sol
@@ -326,15 +326,15 @@ contract Bid_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
         assertEq(inAuction, false);
     }
 
-    function testFuzz_Success_bid_FromContract_Partial(uint112 amountLoaned, uint112 bidAssetAmount, bytes memory data)
+    function testFuzz_Success_bid_FromContract_Partial(uint256 amountToken1, uint112 bidAssetAmount, bytes memory data)
         public
     {
         // Given: Bidder is a contract.
         Bidder bidder = new Bidder();
 
-        // And: The account auction is initiated
-        amountLoaned = uint112(bound(amountLoaned, 1, type(uint112).max - 1));
-        initiateLiquidation(amountLoaned);
+        // And: The account auction is initiated, with token1 as collateral and stable1 as numeraire.
+        amountToken1 = bound(amountToken1, 1e12, 1e30);
+        initiateLiquidationToken1(amountToken1);
 
         uint256[] memory originalAssetAmounts = liquidator.getAuctionAssetAmounts(address(account));
         uint256 originalAmount = originalAssetAmounts[0];
@@ -359,6 +359,7 @@ contract Bid_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
         // Get Initial balances.
         uint256 initialBalancePool = mockERC20.stable1.balanceOf(address(pool));
         uint256 initialBalanceBidder = mockERC20.stable1.balanceOf(address(bidder));
+        uint256 initialCollateralBidder = mockERC20.token1.balanceOf(address(bidder));
 
         // When: Bidder bids for the asset
         // Then: Bidder contract gets called with the actual amounts transferred and actual bid price.
@@ -368,21 +369,21 @@ contract Bid_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
 
         // And: Tokens are transferred.
         assertEq(mockERC20.stable1.balanceOf(address(pool)), initialBalancePool + price);
-        // ToDo: collateral and numeraire are both stable1 -> balance of bidder increases and decreases -> use two different tokens.
-        assertEq(mockERC20.stable1.balanceOf(address(bidder)), initialBalanceBidder - price + bidAssetAmount);
+        assertEq(mockERC20.stable1.balanceOf(address(bidder)), initialBalanceBidder - price);
+        assertEq(mockERC20.token1.balanceOf(address(bidder)), initialCollateralBidder + bidAssetAmount);
     }
 
     function testFuzz_Success_bid_FromContract_BidExceeding(
-        uint112 amountLoaned,
+        uint256 amountToken1,
         uint112 bidAssetAmount,
         bytes memory data
     ) public {
         // Given: Bidder is a contract.
         Bidder bidder = new Bidder();
 
-        // And: The account auction is initiated
-        amountLoaned = uint112(bound(amountLoaned, 1, type(uint112).max - 1));
-        initiateLiquidation(amountLoaned);
+        // And: The account auction is initiated, with token1 as collateral and stable1 as numeraire.
+        amountToken1 = bound(amountToken1, 1e12, 1e30);
+        initiateLiquidationToken1(amountToken1);
 
         uint256[] memory originalAssetAmounts = liquidator.getAuctionAssetAmounts(address(account));
         uint256 originalAmount = originalAssetAmounts[0];
@@ -407,6 +408,7 @@ contract Bid_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
         // Get Initial balances.
         uint256 initialBalancePool = mockERC20.stable1.balanceOf(address(pool));
         uint256 initialBalanceBidder = mockERC20.stable1.balanceOf(address(bidder));
+        uint256 initialCollateralBidder = mockERC20.token1.balanceOf(address(bidder));
 
         // When: Bidder bids for the asset
         // Then: Bidder contract gets called with the actual amounts transferred and actual bid price.
@@ -416,7 +418,7 @@ contract Bid_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
 
         // And: Tokens are transferred.
         assertEq(mockERC20.stable1.balanceOf(address(pool)), initialBalancePool + price);
-        // ToDo: collateral and numeraire are both stable1 -> balance of bidder increases and decreases -> use two different tokens.
-        assertEq(mockERC20.stable1.balanceOf(address(bidder)), initialBalanceBidder - price + originalAmount);
+        assertEq(mockERC20.stable1.balanceOf(address(bidder)), initialBalanceBidder - price);
+        assertEq(mockERC20.token1.balanceOf(address(bidder)), initialCollateralBidder + originalAmount);
     }
 }

--- a/test/fuzz/liquidators/LiquidatorL2/CalculateBidPrice.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL2/CalculateBidPrice.fuzz.t.sol
@@ -43,8 +43,7 @@ contract CalculateBidPrice_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
         liquidator.setAuctionCurveParameters(halfLifeTime, cutoffTime, startPriceMultiplier, minPriceMultiplier);
 
         // And: The account auction is initiated.
-        vm.assume(amountLoaned > 1);
-        vm.assume(amountLoaned <= (type(uint112).max / 300) * 100);
+        amountLoaned = uint112(bound(amountLoaned, 1 + 1, (type(uint112).max / 300) * 100));
         initiateLiquidation(amountLoaned);
 
         // And: A timestamp far beyond the cutoffTime, where the price curve underflows the LogExpMath precision.

--- a/test/fuzz/liquidators/LiquidatorL2/EndAuction.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL2/EndAuction.fuzz.t.sol
@@ -40,8 +40,7 @@ contract EndAuction_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
 
     function testFuzz_Revert_endAuction_SequencerDown(address caller, uint112 amountLoaned, uint32 startedAt) public {
         // Given: The account auction is initiated.
-        vm.assume(amountLoaned > 1);
-        vm.assume(amountLoaned <= (type(uint112).max / 300) * 100);
+        amountLoaned = uint112(bound(amountLoaned, 1 + 1, (type(uint112).max / 300) * 100));
         initiateLiquidation(0, amountLoaned);
 
         // And: The sequencer is down.

--- a/test/fuzz/liquidators/LiquidatorL2/GetAssetShares.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL2/GetAssetShares.fuzz.t.sol
@@ -53,7 +53,7 @@ contract GetAssetShares_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
             assetValues[i].assetValue = bound(assetValues[i].assetValue, 0, type(uint112).max);
             totalValue += assetValues[i].assetValue;
         }
-        vm.assume(totalValue > 0);
+        totalValue = bound(totalValue, 1, type(uint256).max);
 
         vm.assume(totalValue != 0);
 

--- a/test/fuzz/liquidators/LiquidatorL2/GetBidPrice.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL2/GetBidPrice.fuzz.t.sol
@@ -26,8 +26,7 @@ contract GetBidPrice_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
 
     function testFuzz_Revert_getBidPrice_AssetAmountsShorter(address bidder, uint112 amountLoaned) public {
         // Given: The account auction is initiated
-        vm.assume(amountLoaned > 1);
-        vm.assume(amountLoaned <= (type(uint112).max / 300) * 100);
+        amountLoaned = uint112(bound(amountLoaned, 1 + 1, (type(uint112).max / 300) * 100));
         initiateLiquidation(amountLoaned);
 
         // When: getBidPrice is called with fewer asset amounts than the auction.
@@ -40,8 +39,7 @@ contract GetBidPrice_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
 
     function testFuzz_Revert_getBidPrice_AfterCutoff(address bidder, uint112 amountLoaned, uint32 timePassed) public {
         // Given: The account auction is initiated.
-        vm.assume(amountLoaned > 1);
-        vm.assume(amountLoaned <= (type(uint112).max / 300) * 100);
+        amountLoaned = uint112(bound(amountLoaned, 1 + 1, (type(uint112).max / 300) * 100));
         initiateLiquidation(amountLoaned);
 
         // And: A timestamp far beyond the cutoffTime, where the price curve underflows the LogExpMath precision.

--- a/test/fuzz/liquidators/LiquidatorL2/LiquidateAccount.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL2/LiquidateAccount.fuzz.t.sol
@@ -15,7 +15,7 @@ import { stdStorage, StdStorage } from "../../../../lib/accounts-v2/lib/forge-st
 /**
  * @notice Fuzz tests for the function "liquidateAccount" of contract "LiquidatorL2".
  */
-// forge-lint: disable-next-item(divide-before-multiply)
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract LiquidateAccount_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
     using FixedPointMathLib for uint256;
     using stdStorage for StdStorage;
@@ -45,8 +45,7 @@ contract LiquidateAccount_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
     {
         // Given: Account auction is already started
         bytes3 emptyBytes3;
-        vm.assume(amountLoaned > 1);
-        vm.assume(amountLoaned <= (type(uint112).max / 150) * 100); // No overflow when debt is increased
+        amountLoaned = uint112(bound(amountLoaned, 1 + 1, (type(uint112).max / 150) * 100));
         depositErc20InAccount(account, mockERC20.stable1, amountLoaned);
         vm.prank(users.liquidityProvider);
         mockERC20.stable1.approve(address(pool), type(uint256).max);
@@ -111,8 +110,7 @@ contract LiquidateAccount_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
     ) public {
         // Given: Account has debt
         bytes3 emptyBytes3;
-        vm.assume(amountLoaned > 0);
-        vm.assume(amountLoaned <= type(uint112).max - 2); // No overflow when debt is increased
+        amountLoaned = uint112(bound(amountLoaned, 1, type(uint112).max - 2)); // No overflow when debt is increased
         depositErc20InAccount(account, mockERC20.stable1, amountLoaned);
         vm.prank(users.liquidityProvider);
         mockERC20.stable1.approve(address(pool), type(uint256).max);
@@ -139,9 +137,10 @@ contract LiquidateAccount_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
         uint80 maxReward,
         address liquidationInitiator
     ) public {
-        vm.assume(amountLoaned > 1);
-        vm.assume(amountLoaned <= (type(uint112).max / 300) * 100); // No overflow when debt is increased
-        vm.assume(uint32(initiationWeight) + penaltyWeight + terminationWeight <= 1100);
+        amountLoaned = uint112(bound(amountLoaned, 1 + 1, (type(uint112).max / 300) * 100)); // No overflow when debt is increased
+        initiationWeight = uint16(bound(initiationWeight, 0, 1100));
+        penaltyWeight = uint16(bound(penaltyWeight, 0, 1100 - initiationWeight));
+        terminationWeight = uint16(bound(terminationWeight, 0, 1100 - initiationWeight - penaltyWeight));
 
         // Given: Account has debt
         bytes3 emptyBytes3;
@@ -187,12 +186,10 @@ contract LiquidateAccount_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
         uint80 maxReward,
         address liquidationInitiator
     ) public {
-        vm.assume(amountLoaned > 1);
-        vm.assume(amountLoaned <= (type(uint112).max / 300) * 100); // No overflow when debt is increased
-        vm.assume(uint256(amountLoaned) * initiationWeight <= (type(uint256).max));
-        vm.assume(uint256(amountLoaned) * terminationWeight <= (type(uint256).max));
-        vm.assume(uint256(amountLoaned) * penaltyWeight <= (type(uint256).max));
-        vm.assume(uint32(initiationWeight) + penaltyWeight + terminationWeight <= 1100);
+        amountLoaned = uint112(bound(amountLoaned, 1 + 1, (type(uint112).max / 300) * 100)); // No overflow when debt is increased
+        initiationWeight = uint16(bound(initiationWeight, 0, 1100));
+        penaltyWeight = uint16(bound(penaltyWeight, 0, 1100 - initiationWeight));
+        terminationWeight = uint16(bound(terminationWeight, 0, 1100 - initiationWeight - penaltyWeight));
 
         // Given: Account has debt
         bytes3 emptyBytes3;
@@ -253,9 +250,10 @@ contract LiquidateAccount_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
         uint80 maxReward,
         address liquidationInitiator
     ) public {
-        vm.assume(amountLoaned > 1);
-        vm.assume(amountLoaned <= (type(uint112).max / 300) * 100); // No overflow when debt is increased
-        vm.assume(uint16(initiationWeight) + penaltyWeight + terminationWeight <= 1100);
+        amountLoaned = uint112(bound(amountLoaned, 1 + 1, (type(uint112).max / 300) * 100)); // No overflow when debt is increased
+        initiationWeight = uint8(bound(initiationWeight, 0, 1100));
+        penaltyWeight = uint8(bound(penaltyWeight, 0, 1100 - initiationWeight));
+        terminationWeight = uint8(bound(terminationWeight, 0, 1100 - initiationWeight - penaltyWeight));
 
         // Given: Account has debt
         bytes3 emptyBytes3;
@@ -304,9 +302,10 @@ contract LiquidateAccount_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
         uint80 maxReward,
         address liquidationInitiator
     ) public {
-        vm.assume(amountLoaned > 1);
-        vm.assume(amountLoaned <= (type(uint112).max / 300) * 100); // No overflow when debt is increased
-        vm.assume(uint16(initiationWeight) + penaltyWeight + terminationWeight <= 1100);
+        amountLoaned = uint112(bound(amountLoaned, 1 + 1, (type(uint112).max / 300) * 100)); // No overflow when debt is increased
+        initiationWeight = uint8(bound(initiationWeight, 0, 1100));
+        penaltyWeight = uint8(bound(penaltyWeight, 0, 1100 - initiationWeight));
+        terminationWeight = uint8(bound(terminationWeight, 0, 1100 - initiationWeight - penaltyWeight));
 
         // Given: Account has debt
         bytes3 emptyBytes3;

--- a/test/fuzz/liquidators/LiquidatorL2/SettleAuction.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL2/SettleAuction.fuzz.t.sol
@@ -14,7 +14,7 @@ import { stdStorage, StdStorage } from "../../../../lib/accounts-v2/lib/forge-st
  * @dev "_settleAuction" has no own reverts, it returns a bool indicating if a termination condition was met.
  * Each test asserts the returned bool and the side effects of the matched condition.
  */
-// forge-lint: disable-next-item(unsafe-typecast)
+// forge-lint: disable-next-item(unsafe-typecast,divide-before-multiply)
 contract SettleAuction_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////
@@ -223,9 +223,8 @@ contract SettleAuction_LiquidatorL2_Fuzz_Test is LiquidatorL2_Fuzz_Test {
         vm.assume(bidder != address(0));
 
         // And: The account auction is initiated.
-        vm.assume(amountLoaned > 12);
+        amountLoaned = uint112(bound(amountLoaned, 12 + 1, (type(uint112).max / 300) * 100));
         // forge-lint: disable-next-line(divide-before-multiply)
-        vm.assume(amountLoaned <= (type(uint112).max / 300) * 100);
         initiateLiquidation(amountLoaned);
 
         // And: The auction price decayed below the open debt, within the cutoffTime.

--- a/test/fuzz/liquidators/LiquidatorL2/_LiquidatorL2.fuzz.t.sol
+++ b/test/fuzz/liquidators/LiquidatorL2/_LiquidatorL2.fuzz.t.sol
@@ -36,6 +36,49 @@ abstract contract LiquidatorL2_Fuzz_Test is Fuzz_Lending_Test {
                         HELPER FUNCTIONS
     /////////////////////////////////////////////////////////////// */
 
+    // forge-lint: disable-next-item(unsafe-typecast)
+    function initiateLiquidationToken1(uint256 amountToken1) public returns (uint256 amountLoaned) {
+        vm.prank(users.riskManager);
+        registry.setRiskParametersOfPrimaryAsset(
+            address(pool), address(mockERC20.token1), 0, type(uint112).max, 1e4, 1e4
+        );
+
+        vm.startPrank(users.accountOwner);
+        account.closeMarginAccount();
+        account.openMarginAccount(address(pool));
+        vm.stopPrank();
+
+        depositErc20InAccount(account, mockERC20.token1, amountToken1);
+
+        address[] memory assetAddresses = new address[](1);
+        assetAddresses[0] = address(mockERC20.token1);
+        uint256[] memory assetIds = new uint256[](1);
+        uint256[] memory assetAmounts = new uint256[](1);
+        assetAmounts[0] = amountToken1;
+        amountLoaned = registry.getCollateralValue(
+            address(mockERC20.stable1), address(pool), assetAddresses, assetIds, assetAmounts
+        );
+        vm.assume(amountLoaned > 2);
+        vm.assume(amountLoaned < type(uint112).max);
+
+        bytes3 emptyBytes3;
+        vm.prank(users.liquidityProvider);
+        mockERC20.stable1.approve(address(pool), type(uint256).max);
+        vm.prank(address(srTranche));
+        pool.depositInLendingPool(amountLoaned, users.liquidityProvider);
+        vm.prank(users.accountOwner);
+        pool.borrow(uint112(amountLoaned), address(account), users.accountOwner, emptyBytes3);
+
+        debt.setRealisedDebt(amountLoaned + 1);
+        stdstore.target(address(pool))
+            .sig(pool.liquidityOf.selector)
+            .with_key(address(srTranche))
+            .checked_write(amountLoaned + 1);
+        pool.setTotalRealisedLiquidity(uint128(amountLoaned + 1));
+
+        liquidator.liquidateAccount(address(account));
+    }
+
     function initiateLiquidation(uint112 amountLoaned) public {
         initiateLiquidation(0, amountLoaned);
     }

--- a/test/scenario/BorrowAndRepay.scenario.t.sol
+++ b/test/scenario/BorrowAndRepay.scenario.t.sol
@@ -315,7 +315,7 @@ contract BorrowAndRepay_Scenario_Test is Scenario_Lending_Test {
         // Given: collateralValue is smaller than maxExposure and its value does not overflow.
         uint256 maxAmountToken = type(uint128).max / valueOfOneToken - 1;
         if (maxAmountToken > type(uint112).max - 1) maxAmountToken = type(uint112).max - 1;
-        // And: the collateral is worth at least one unit of credit.
+        // And: The collateral is worth at least one unit of credit.
         uint256 minAmountToken =
             (AssetValuationLib.ONE_4 * 10 ** (18 - Constants.STABLE_DECIMALS) - 1) / collFactor_ + 1;
         minAmountToken = (minAmountToken * 10 ** Constants.TOKEN_DECIMALS - 1) / valueOfOneToken + 1;
@@ -355,7 +355,7 @@ contract BorrowAndRepay_Scenario_Test is Scenario_Lending_Test {
         // Given: collateralValue is smaller than maxExposure and its value does not overflow.
         uint256 maxAmountToken = type(uint128).max / valueOfOneToken - 1;
         if (maxAmountToken > type(uint112).max - 1) maxAmountToken = type(uint112).max - 1;
-        // And: the collateral is worth at least one unit of credit.
+        // And: The collateral is worth at least one unit of credit.
         uint256 minAmountToken =
             (AssetValuationLib.ONE_4 * 10 ** (18 - Constants.STABLE_DECIMALS) - 1) / collFactor_ + 1;
         minAmountToken = (minAmountToken * 10 ** Constants.TOKEN_DECIMALS - 1) / valueOfOneToken + 1;
@@ -399,7 +399,7 @@ contract BorrowAndRepay_Scenario_Test is Scenario_Lending_Test {
         // Given: collateralValue is smaller than maxExposure and its value does not overflow.
         uint256 maxAmountToken = type(uint128).max / valueOfOneToken - 1;
         if (maxAmountToken > type(uint112).max - 1) maxAmountToken = type(uint112).max - 1;
-        // And: the collateral is worth at least one unit of credit.
+        // And: The collateral is worth at least one unit of credit.
         uint256 minAmountToken =
             (AssetValuationLib.ONE_4 * 10 ** (18 - Constants.STABLE_DECIMALS) - 1) / collFactor_ + 1;
         minAmountToken = (minAmountToken * 10 ** Constants.TOKEN_DECIMALS - 1) / valueOfOneToken + 1;

--- a/test/scenario/BorrowAndRepay.scenario.t.sol
+++ b/test/scenario/BorrowAndRepay.scenario.t.sol
@@ -46,11 +46,9 @@ contract BorrowAndRepay_Scenario_Test is Scenario_Lending_Test {
         public
     {
         // Given: collateralValue is smaller than maxExposure.
-        amountToken = uint112(bound(amountToken, 0, type(uint112).max - 1));
+        amountToken = uint112(bound(amountToken, 1, type(uint112).max - 1));
 
-        vm.assume(amountToken > 0);
         uint16 collFactor_ = Constants.TOKEN_TO_STABLE_COLL_FACTOR;
-        vm.assume(uint256(amountCredit) * collFactor_ < type(uint128).max); //prevent overflow in takecredit with absurd values
         uint256 valueOfOneToken = (Constants.WAD * rates.token1ToUsd) / 10 ** Constants.TOKEN_ORACLE_DECIMALS;
 
         depositErc20InAccount(account, mockERC20.token1, amountToken);
@@ -58,7 +56,7 @@ contract BorrowAndRepay_Scenario_Test is Scenario_Lending_Test {
         uint256 maxCredit = ((valueOfOneToken * amountToken) / 10 ** Constants.TOKEN_DECIMALS) * collFactor_
             / AssetValuationLib.ONE_4 / 10 ** (18 - Constants.STABLE_DECIMALS);
 
-        vm.assume(amountCredit > maxCredit);
+        amountCredit = uint112(bound(amountCredit, maxCredit + 1, type(uint112).max));
 
         vm.startPrank(users.accountOwner);
         vm.expectRevert(AccountErrors.AccountUnhealthy.selector);
@@ -69,11 +67,11 @@ contract BorrowAndRepay_Scenario_Test is Scenario_Lending_Test {
     }
 
     function testScenario_Revert_borrow_NotAllowCreditAfterLargeUnrealizedDebt(uint112 amountToken) public {
-        // Given: collateralValue is smaller than maxExposure.
-        amountToken = uint112(bound(amountToken, 0, type(uint112).max - 1));
-
         uint128 valueOfOneToken = uint128((Constants.WAD * rates.token1ToUsd) / 10 ** Constants.TOKEN_ORACLE_DECIMALS);
-        vm.assume(amountToken < type(uint128).max / valueOfOneToken);
+        // Given: collateralValue is smaller than maxExposure and its value does not overflow.
+        uint256 maxAmountToken = type(uint128).max / valueOfOneToken - 1;
+        if (maxAmountToken > type(uint112).max - 1) maxAmountToken = type(uint112).max - 1;
+        amountToken = uint112(bound(amountToken, 1, maxAmountToken));
 
         uint16 collFactor_ = Constants.TOKEN_TO_STABLE_COLL_FACTOR;
         uint128 amountCredit = uint128(
@@ -100,15 +98,16 @@ contract BorrowAndRepay_Scenario_Test is Scenario_Lending_Test {
         uint112 amountTokenWithdrawal,
         uint128 amountCredit
     ) public {
-        // Given: collateralValue is smaller than maxExposure.
-        amountToken = uint112(bound(amountToken, 0, type(uint112).max - 1));
-
-        vm.assume(amountToken > 0 && amountTokenWithdrawal > 0);
         uint16 collFactor_ = Constants.TOKEN_TO_STABLE_COLL_FACTOR;
-        vm.assume(amountToken >= amountTokenWithdrawal);
 
         uint256 valueOfOneToken = (Constants.WAD * rates.token1ToUsd) / 10 ** Constants.TOKEN_ORACLE_DECIMALS;
-        vm.assume(amountToken < type(uint128).max / valueOfOneToken);
+        // Given: collateralValue is smaller than maxExposure and its value does not overflow.
+        uint256 maxAmountToken = type(uint128).max / valueOfOneToken - 1;
+        if (maxAmountToken > type(uint112).max - 1) maxAmountToken = type(uint112).max - 1;
+        amountToken = uint112(bound(amountToken, 1, maxAmountToken));
+
+        // And: the withdrawal is not bigger than the deposit.
+        amountTokenWithdrawal = uint112(bound(amountTokenWithdrawal, 1, amountToken));
 
         depositErc20InAccount(account, mockERC20.token1, amountToken);
 
@@ -155,11 +154,9 @@ contract BorrowAndRepay_Scenario_Test is Scenario_Lending_Test {
 
     function testScenario_Success_borrow_AllowCreditAfterDeposit(uint112 amountToken, uint128 amountCredit) public {
         // Given: collateralValue is smaller than maxExposure.
-        amountToken = uint112(bound(amountToken, 0, type(uint112).max - 1));
+        amountToken = uint112(bound(amountToken, 1, type(uint112).max - 1));
 
         uint16 collFactor_ = Constants.TOKEN_TO_STABLE_COLL_FACTOR;
-        vm.assume(amountToken > 0);
-        vm.assume(uint256(amountCredit) * collFactor_ < type(uint128).max); //prevent overflow in takecredit with absurd values
         uint256 valueOfOneToken = (Constants.WAD * rates.token1ToUsd) / 10 ** Constants.TOKEN_ORACLE_DECIMALS;
 
         depositErc20InAccount(account, mockERC20.token1, amountToken);
@@ -167,6 +164,9 @@ contract BorrowAndRepay_Scenario_Test is Scenario_Lending_Test {
         uint256 maxCredit =
             ((valueOfOneToken * amountToken) / 10 ** Constants.TOKEN_DECIMALS * collFactor_ / AssetValuationLib.ONE_4
                 / 10 ** (18 - Constants.STABLE_DECIMALS));
+
+        // And: Taking the credit does not overflow.
+        if (maxCredit >= type(uint128).max / collFactor_) maxCredit = type(uint128).max / collFactor_ - 1;
 
         vm.assume(maxCredit > 0);
         amountCredit = uint128(bound(amountCredit, 1, maxCredit));
@@ -184,14 +184,11 @@ contract BorrowAndRepay_Scenario_Test is Scenario_Lending_Test {
         uint24 deltaTimestamp
     ) public {
         // Given: collateralValue is smaller than maxExposure.
-        amountToken = uint112(bound(amountToken, 0, type(uint112).max - 1));
+        amountToken = uint112(bound(amountToken, 1, type(uint112).max - 1));
 
-        vm.assume(amountToken > 0);
         uint256 _yearlyInterestRate = pool.interestRate();
         uint128 base = 1e18 + 5e16; //1 + r expressed as 18 decimals fixed point number
         uint128 exponent = (uint128(deltaTimestamp) * 1e18) / uint128(pool.getYearlySeconds());
-        vm.assume(amountCredit < type(uint128).max / LogExpMath.pow(base, exponent));
-
         uint256 valueOfOneToken = (Constants.WAD * rates.token1ToUsd) / 10 ** Constants.TOKEN_ORACLE_DECIMALS;
 
         depositErc20InAccount(account, mockERC20.token1, amountToken);
@@ -200,6 +197,10 @@ contract BorrowAndRepay_Scenario_Test is Scenario_Lending_Test {
         uint256 maxCredit =
             ((valueOfOneToken * amountToken) / 10 ** Constants.TOKEN_DECIMALS * collFactor_ / AssetValuationLib.ONE_4
                 / 10 ** (18 - Constants.STABLE_DECIMALS));
+
+        // And: The debt does not overflow when the interest compounds.
+        uint256 maxDebt = type(uint128).max / LogExpMath.pow(base, exponent);
+        if (maxCredit >= maxDebt) maxCredit = maxDebt - 1;
 
         vm.assume(maxCredit > 0);
         amountCredit = uint128(bound(amountCredit, 1, maxCredit));
@@ -234,10 +235,10 @@ contract BorrowAndRepay_Scenario_Test is Scenario_Lending_Test {
         uint16 newPrice
     ) public {
         // Given: collateralValue is smaller than maxExposure.
-        amountToken = uint112(bound(amountToken, 0, type(uint112).max - 1));
+        amountToken = uint112(bound(amountToken, 1, type(uint112).max - 1));
 
-        vm.assume(amountToken > 0);
-        vm.assume(newPrice * 10 ** Constants.TOKEN_ORACLE_DECIMALS > rates.token1ToUsd);
+        newPrice =
+            uint16(bound(newPrice, rates.token1ToUsd / 10 ** Constants.TOKEN_ORACLE_DECIMALS + 1, type(uint16).max));
         uint16 collFactor_ = Constants.TOKEN_TO_STABLE_COLL_FACTOR;
         uint256 valueOfOneToken = uint128((Constants.WAD * rates.token1ToUsd) / 10 ** Constants.TOKEN_ORACLE_DECIMALS);
 
@@ -271,15 +272,16 @@ contract BorrowAndRepay_Scenario_Test is Scenario_Lending_Test {
         uint112 amountTokenWithdrawal,
         uint128 amountCredit
     ) public {
-        // Given: collateralValue is smaller than maxExposure.
-        amountToken = uint112(bound(amountToken, 0, type(uint112).max - 1));
-
-        vm.assume(amountToken > 0 && amountTokenWithdrawal > 0);
         uint16 collFactor_ = Constants.TOKEN_TO_STABLE_COLL_FACTOR;
-        vm.assume(amountToken >= amountTokenWithdrawal);
 
         uint256 valueOfOneToken = (Constants.WAD * rates.token1ToUsd) / 10 ** Constants.TOKEN_ORACLE_DECIMALS;
-        vm.assume(amountToken < type(uint128).max / valueOfOneToken);
+        // Given: collateralValue is smaller than maxExposure and its value does not overflow.
+        uint256 maxAmountToken = type(uint128).max / valueOfOneToken - 1;
+        if (maxAmountToken > type(uint112).max - 1) maxAmountToken = type(uint112).max - 1;
+        amountToken = uint112(bound(amountToken, 1, maxAmountToken));
+
+        // And: the withdrawal is not bigger than the deposit.
+        amountTokenWithdrawal = uint112(bound(amountTokenWithdrawal, 1, amountToken));
 
         depositErc20InAccount(account, mockERC20.token1, amountToken);
 
@@ -307,19 +309,21 @@ contract BorrowAndRepay_Scenario_Test is Scenario_Lending_Test {
         uint128 amountCredit,
         uint24 deltaTimestamp
     ) public {
-        // Given: collateralValue is smaller than maxExposure.
-        amountToken = uint112(bound(amountToken, 0, type(uint112).max - 1));
-
-        vm.assume(amountToken > 0);
         uint16 collFactor_ = Constants.TOKEN_TO_STABLE_COLL_FACTOR;
 
         uint256 valueOfOneToken = (Constants.WAD * rates.token1ToUsd) / 10 ** Constants.TOKEN_ORACLE_DECIMALS;
-        vm.assume(amountToken < type(uint128).max / valueOfOneToken);
+        // Given: collateralValue is smaller than maxExposure and its value does not overflow.
+        uint256 maxAmountToken = type(uint128).max / valueOfOneToken - 1;
+        if (maxAmountToken > type(uint112).max - 1) maxAmountToken = type(uint112).max - 1;
+        // And: the collateral is worth at least one unit of credit.
+        uint256 minAmountToken =
+            (AssetValuationLib.ONE_4 * 10 ** (18 - Constants.STABLE_DECIMALS) - 1) / collFactor_ + 1;
+        minAmountToken = (minAmountToken * 10 ** Constants.TOKEN_DECIMALS - 1) / valueOfOneToken + 1;
+        amountToken = uint112(bound(amountToken, minAmountToken, maxAmountToken));
 
         uint256 maxCredit = ((valueOfOneToken * amountToken) / 10 ** Constants.TOKEN_DECIMALS) * collFactor_
             / AssetValuationLib.ONE_4 / 10 ** (18 - Constants.STABLE_DECIMALS);
 
-        vm.assume(maxCredit > 0);
         amountCredit = uint128(bound(amountCredit, 1, maxCredit));
 
         depositErc20InAccount(account, mockERC20.token1, amountToken);
@@ -345,20 +349,21 @@ contract BorrowAndRepay_Scenario_Test is Scenario_Lending_Test {
     function testScenario_Success_repay_ExactDebt(uint112 amountToken, uint128 amountCredit, uint16 blocksToRoll)
         public
     {
-        // Given: collateralValue is smaller than maxExposure.
-        amountToken = uint112(bound(amountToken, 0, type(uint112).max - 1));
-
-        vm.assume(amountToken > 0);
-        vm.assume(amountCredit > 0);
         uint16 collFactor_ = Constants.TOKEN_TO_STABLE_COLL_FACTOR;
 
         uint256 valueOfOneToken = (Constants.WAD * rates.token1ToUsd) / 10 ** Constants.TOKEN_ORACLE_DECIMALS;
-        vm.assume(amountToken < type(uint128).max / valueOfOneToken);
+        // Given: collateralValue is smaller than maxExposure and its value does not overflow.
+        uint256 maxAmountToken = type(uint128).max / valueOfOneToken - 1;
+        if (maxAmountToken > type(uint112).max - 1) maxAmountToken = type(uint112).max - 1;
+        // And: the collateral is worth at least one unit of credit.
+        uint256 minAmountToken =
+            (AssetValuationLib.ONE_4 * 10 ** (18 - Constants.STABLE_DECIMALS) - 1) / collFactor_ + 1;
+        minAmountToken = (minAmountToken * 10 ** Constants.TOKEN_DECIMALS - 1) / valueOfOneToken + 1;
+        amountToken = uint112(bound(amountToken, minAmountToken, maxAmountToken));
 
         uint256 maxCredit = ((valueOfOneToken * amountToken) / 10 ** Constants.TOKEN_DECIMALS) * collFactor_
             / AssetValuationLib.ONE_4 / 10 ** (18 - Constants.STABLE_DECIMALS);
 
-        vm.assume(maxCredit > 0);
         amountCredit = uint128(bound(amountCredit, 1, maxCredit));
 
         depositErc20InAccount(account, mockERC20.token1, amountToken);
@@ -387,21 +392,22 @@ contract BorrowAndRepay_Scenario_Test is Scenario_Lending_Test {
         uint16 blocksToRoll,
         uint8 factor
     ) public {
-        // Given: collateralValue is smaller than maxExposure.
-        amountToken = uint112(bound(amountToken, 0, type(uint112).max - 1));
-
-        vm.assume(amountToken > 0);
-        vm.assume(factor > 0);
-        vm.assume(amountCredit > 0);
+        factor = uint8(bound(factor, 1, type(uint8).max));
         uint16 collFactor_ = Constants.TOKEN_TO_STABLE_COLL_FACTOR;
 
         uint256 valueOfOneToken = (Constants.WAD * rates.token1ToUsd) / 10 ** Constants.TOKEN_ORACLE_DECIMALS;
-        vm.assume(amountToken < type(uint128).max / valueOfOneToken);
+        // Given: collateralValue is smaller than maxExposure and its value does not overflow.
+        uint256 maxAmountToken = type(uint128).max / valueOfOneToken - 1;
+        if (maxAmountToken > type(uint112).max - 1) maxAmountToken = type(uint112).max - 1;
+        // And: the collateral is worth at least one unit of credit.
+        uint256 minAmountToken =
+            (AssetValuationLib.ONE_4 * 10 ** (18 - Constants.STABLE_DECIMALS) - 1) / collFactor_ + 1;
+        minAmountToken = (minAmountToken * 10 ** Constants.TOKEN_DECIMALS - 1) / valueOfOneToken + 1;
+        amountToken = uint112(bound(amountToken, minAmountToken, maxAmountToken));
 
         uint256 maxCredit = ((valueOfOneToken * amountToken) / 10 ** Constants.TOKEN_DECIMALS) * collFactor_
             / AssetValuationLib.ONE_4 / 10 ** (18 - Constants.STABLE_DECIMALS);
 
-        vm.assume(maxCredit > 0);
         amountCredit = uint128(bound(amountCredit, 1, maxCredit));
 
         depositErc20InAccount(account, mockERC20.token1, amountToken);
@@ -435,21 +441,22 @@ contract BorrowAndRepay_Scenario_Test is Scenario_Lending_Test {
         uint24 deltaTimestamp,
         uint128 toRepay
     ) public {
-        // Given: collateralValue is smaller than maxExposure.
-        amountToken = uint112(bound(amountToken, 0, type(uint112).max - 1));
-
-        vm.assume(amountToken > 0);
-        vm.assume(toRepay > 0);
         uint16 collFactor_ = Constants.TOKEN_TO_STABLE_COLL_FACTOR;
 
         uint256 valueOfOneToken = (Constants.WAD * rates.token1ToUsd) / 10 ** Constants.TOKEN_ORACLE_DECIMALS;
-        vm.assume(amountToken < type(uint128).max / valueOfOneToken);
+        // Given: collateralValue is smaller than maxExposure and its value does not overflow.
+        uint256 maxAmountToken = type(uint128).max / valueOfOneToken - 1;
+        if (maxAmountToken > type(uint112).max - 1) maxAmountToken = type(uint112).max - 1;
+        amountToken = uint112(bound(amountToken, 1, maxAmountToken));
 
         uint256 maxCredit = ((valueOfOneToken * amountToken) / 10 ** Constants.TOKEN_DECIMALS) * collFactor_
             / AssetValuationLib.ONE_4 / 10 ** (18 - Constants.STABLE_DECIMALS);
 
-        vm.assume(maxCredit > 0);
-        amountCredit = uint128(bound(amountCredit, 1, maxCredit));
+        vm.assume(maxCredit > 1);
+        amountCredit = uint128(bound(amountCredit, 2, maxCredit));
+
+        // And: Only part of the credit is repaid.
+        toRepay = uint128(bound(toRepay, 1, uint256(amountCredit) - 1));
 
         depositErc20InAccount(account, mockERC20.token1, amountToken);
 
@@ -463,7 +470,6 @@ contract BorrowAndRepay_Scenario_Test is Scenario_Lending_Test {
         // total liquidity does not overflow.
         vm.assume(pool.calcUnrealisedDebt() + totalLiquidity <= type(uint128).max);
 
-        vm.assume(toRepay < amountCredit);
         vm.assume(debt.previewWithdraw(toRepay) > 0);
 
         vm.prank(users.accountOwner);

--- a/test/scenario/LeveragedActions.scenario.t.sol
+++ b/test/scenario/LeveragedActions.scenario.t.sol
@@ -21,7 +21,7 @@ import { LendingPoolErrors } from "../../src/libraries/Errors.sol";
 /**
  * @notice Scenario tests for With Leveraged Actions flows.
  */
-// forge-lint: disable-next-item(divide-before-multiply)
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract LeveragedActions_Scenario_Test is Scenario_Lending_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////
@@ -168,14 +168,18 @@ contract LeveragedActions_Scenario_Test is Scenario_Lending_Test {
             ** Constants.STABLE_DECIMALS / stableRate;
 
         //With leverage -> stableIn should be bigger than the available collateral
-        vm.assume(stableIn > stableCollateral);
+        vm.assume(stableIn > 0);
+        stableCollateral =
+            uint64(bound(stableCollateral, 0, stableIn - 1 > type(uint64).max ? type(uint64).max : stableIn - 1));
 
         uint256 stableMargin = stableIn - stableCollateral;
 
         //Action is not successfull -> total debt after transaction should be bigger than the Collateral Value
         uint256 collValue = uint256(tokenOut) * tokenRate / 10 ** Constants.TOKEN_DECIMALS
             * Constants.TOKEN_TO_STABLE_COLL_FACTOR / 100 * 10 ** Constants.STABLE_DECIMALS / stableRate;
-        vm.assume(stableMargin + stableDebt > collValue);
+        vm.assume(collValue < stableMargin + type(uint64).max);
+        stableDebt =
+            uint64(bound(stableDebt, collValue >= stableMargin ? collValue - stableMargin + 1 : 0, type(uint64).max));
 
         //Set initial debt
         stdstore.target(address(debt)).sig(debt.totalSupply.selector).checked_write(stableDebt);
@@ -265,12 +269,19 @@ contract LeveragedActions_Scenario_Test is Scenario_Lending_Test {
         }
 
         //With leverage -> stableIn should be bigger than the available collateral
-        vm.assume(stableIn > stableCollateral);
+        vm.assume(stableIn > 0);
+        stableCollateral =
+            uint72(bound(stableCollateral, 0, stableIn - 1 > type(uint72).max ? type(uint72).max : stableIn - 1));
 
         uint256 stableMargin = stableIn - stableCollateral;
 
         //Action is successfull -> total debt after transaction should be smaller than the Collateral Value
-        vm.assume(stableMargin + stableDebt <= collValue);
+        vm.assume(collValue >= stableMargin);
+        stableDebt = uint32(
+            bound(
+                stableDebt, 0, collValue - stableMargin > type(uint32).max ? type(uint32).max : collValue - stableMargin
+            )
+        );
 
         //Set initial debt
         stdstore.target(address(debt)).sig(debt.totalSupply.selector).checked_write(stableDebt);
@@ -387,12 +398,19 @@ contract LeveragedActions_Scenario_Test is Scenario_Lending_Test {
         }
 
         //With leverage -> stableIn should be bigger than the available collateral
-        vm.assume(stableIn > stableCollateral);
+        vm.assume(stableIn > 0);
+        stableCollateral =
+            uint72(bound(stableCollateral, 0, stableIn - 1 > type(uint72).max ? type(uint72).max : stableIn - 1));
 
         uint256 stableMargin = stableIn - stableCollateral;
 
         //Action is successfull -> total debt after transaction should be smaller than the Collateral Value
-        vm.assume(stableMargin + stableDebt <= collValue);
+        vm.assume(collValue >= stableMargin);
+        stableDebt = uint32(
+            bound(
+                stableDebt, 0, collValue - stableMargin > type(uint32).max ? type(uint32).max : collValue - stableMargin
+            )
+        );
 
         //Set initial debt
         stdstore.target(address(debt)).sig(debt.totalSupply.selector).checked_write(stableDebt);


### PR DESCRIPTION
Replaces `vm.assume` with `bound` wherever the constrained value is a fuzz input, and fixes bounds that discarded an earlier limit.

- A second `bound` on `amountLoaned` used a lower ceiling than the first, so any value above it was remapped into `[0, ...]`, below the floor the test requires. Merged into a single bound in `LiquidatorL1`/`LiquidatorL2` `Bid` and `LiquidateAccount`.
- `UpdateInterestRate` capped `realisedDebt_` for overflow and then re-bounded it to `totalRealisedLiquidity_`, discarding the overflow cap whenever liquidity exceeded `type(uint128).max / ONE_4`. It now takes the lower of the two.
- `Repay` re-bounded `amountLoaned` after `availableFunds` had been bounded relative to it, breaking the `availableFunds > amountLoaned` invariant. Reordered, and a vacuous cap dropped.
- Bounds `amountToken` in the `BorrowAndRepay` scenarios so `maxCredit` is non-zero by construction.
- Drops an assume already contained in the following line's condition.

`forge test`, `forge lint` and `forge fmt --check` are clean.
